### PR TITLE
Repository foundation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Environment
+
+- macOS version:
+- MakLock version:
+- Mac model:
+- Touch ID available: Yes / No
+
+## Additional Context
+
+Screenshots, logs, or other relevant information.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+What problem does this feature solve?
+
+## Proposed Solution
+
+How should this feature work?
+
+## Alternatives Considered
+
+Any alternative approaches you've thought about.
+
+## Additional Context
+
+Mockups, examples, or references.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Xcode
+build/
+DerivedData/
+*.xcodeproj/xcuserdata/
+*.xcworkspace/xcuserdata/
+*.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+
+# Swift Package Manager
+.build/
+Package.resolved
+
+# macOS
+.DS_Store
+*.swp
+*~
+
+# Local development config
+CLAUDE.md
+CURRENT_TASK.md
+.claude/
+.mcp.json
+
+# Archives and distribution
+*.dmg
+*.zip
+*.app
+*.ipa

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing to MakLock
+
+Thanks for your interest in contributing to MakLock! Here's how to get started.
+
+## Development Setup
+
+### Requirements
+
+- macOS 13.0 (Ventura) or later
+- Xcode 15+
+- Swift 5.9+
+
+### Building from Source
+
+```bash
+git clone https://github.com/dutkiewiczmaciej/maklock.git
+cd maklock
+open MakLock.xcodeproj
+```
+
+Build and run with `Cmd+R` in Xcode. The app runs as a menu bar application (no Dock icon).
+
+## Project Structure
+
+```
+MakLock/
+  App/        - Entry point, AppDelegate, AppState
+  Core/       - Services, Managers, Storage (no UI)
+  UI/         - Design system, Components, Views
+  Models/     - Data models (Codable structs)
+  Resources/  - Assets, Info.plist, Entitlements
+```
+
+## Code Style
+
+- Follow [Apple's API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/)
+- PascalCase for types, camelCase for properties and methods
+- All public API must have documentation comments
+- SwiftUI for UI, AppKit bridging where needed (NSWindow, NSStatusItem)
+
+## Git Conventions
+
+- Branch naming: `feature/description`, `fix/description`, `setup/description`
+- Commit messages: imperative mood, English, under 72 characters
+- One logical change per commit
+
+## Safety Protocol
+
+MakLock includes safety mechanisms to prevent locking yourself out during development:
+
+- **Panic key:** `Cmd+Option+Shift+Control+U` dismisses all overlays instantly
+- **System blacklist:** Terminal, Xcode, Activity Monitor, and other dev tools can never be locked
+- **Dev mode:** In DEBUG builds, overlays auto-dismiss after 10 seconds and include a Skip button
+- **Timeout failsafe:** Overlays auto-dismiss after 60 seconds without interaction
+
+**Always test the panic key before working on overlay code.**
+
+## Submitting Changes
+
+1. Fork the repository
+2. Create a feature branch from `main`
+3. Make your changes
+4. Ensure the project builds without warnings
+5. Submit a pull request with a clear description
+
+## Reporting Issues
+
+Use [GitHub Issues](https://github.com/dutkiewiczmaciej/maklock/issues) with the provided templates for bug reports and feature requests.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Maciej Dutkiewicz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,101 @@
+<p align="center">
+  <img src="Resources/icon.png" width="128" height="128" alt="MakLock icon">
+</p>
+
+<h1 align="center">MakLock</h1>
+
+<p align="center">
+  <strong>Lock any macOS app with Touch ID or password.</strong><br>
+  Free and open source.
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/platform-macOS%2013%2B-black?style=flat-square" alt="Platform">
+  <img src="https://img.shields.io/badge/swift-5.9%2B-FFD213?style=flat-square" alt="Swift">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-white?style=flat-square" alt="License"></a>
+</p>
+
+---
+
+## What is MakLock?
+
+MakLock is a lightweight menu bar app that protects your macOS applications with Touch ID or a backup password. When someone tries to open a protected app, MakLock shows a lock overlay and requires authentication before granting access.
+
+### MakLock vs AppLocker
+
+| Feature | MakLock | AppLocker |
+|---------|:-------:|:---------:|
+| Price | **Free** | $0.99/month |
+| Touch ID unlock | Single prompt | Double prompt |
+| Full-screen overlay | Yes | No |
+| App termination on lock | Yes | No |
+| Auto-lock on idle | Yes | No |
+| Auto-lock on sleep | Yes | No |
+| Apple Watch unlock | Yes | No |
+| Open source | Yes | No |
+
+## Features
+
+- [ ] Menu bar app (no Dock icon)
+- [ ] Lock apps with Touch ID
+- [ ] Password fallback
+- [ ] Full-screen blur overlay
+- [ ] Auto-lock after idle timeout
+- [ ] Auto-lock on sleep/wake
+- [ ] Apple Watch proximity unlock
+- [ ] Panic key emergency exit
+- [ ] System app blacklist (never locks Terminal, Xcode, etc.)
+
+## Screenshots
+
+> Coming soon.
+
+## Installation
+
+### Download
+
+> First release coming soon. Download the latest `.dmg` from [Releases](https://github.com/dutkiewiczmaciej/maklock/releases).
+
+### Build from Source
+
+```bash
+git clone https://github.com/dutkiewiczmaciej/maklock.git
+cd maklock
+open MakLock.xcodeproj
+```
+
+Build and run with `Cmd+R`. Requires Xcode 15+ and macOS 13+.
+
+## Architecture
+
+MakLock is a native Swift/SwiftUI application distributed outside the App Store for full overlay and process management capabilities.
+
+```
+MakLock/
+  App/        Entry point, AppDelegate, AppState
+  Core/       Services, Managers, Storage
+  UI/         Design system, Components, Views
+  Models/     Data models
+  Resources/  Assets, Entitlements
+```
+
+**Key frameworks:** SwiftUI, AppKit, LocalAuthentication, CoreBluetooth, IOKit, HotKey (SPM)
+
+## Safety
+
+MakLock includes multiple safety mechanisms to ensure you never get locked out:
+
+- **Panic key** — `Cmd+Option+Shift+Control+U` instantly dismisses all overlays
+- **System blacklist** — Terminal, Xcode, Activity Monitor, and other system apps can never be locked
+- **Timeout failsafe** — Overlays auto-dismiss after 60 seconds without interaction
+- **Dev mode** — DEBUG builds include a Skip button and 10-second auto-dismiss
+
+## Requirements
+
+- macOS 13.0 (Ventura) or later
+- Apple Silicon or Intel Mac
+- Touch ID recommended (password fallback available)
+
+## License
+
+[MIT](LICENSE) — Made by [MakMak](https://github.com/dutkiewiczmaciej)


### PR DESCRIPTION
## Summary
- Add MIT license (Maciej Dutkiewicz, 2026)
- Add contributing guidelines with development setup and code style
- Add README with project overview, feature comparison, and roadmap
- Add GitHub issue templates for bugs and feature requests

## Changes
- `.gitignore` — Xcode, SPM, macOS, local dev config
- `LICENSE` — MIT
- `CONTRIBUTING.md` — dev setup, code style, safety protocol, git conventions
- `README.md` — badges, feature table (MakLock vs AppLocker), architecture, safety docs
- `.github/ISSUE_TEMPLATE/` — bug report and feature request templates