### PR TITLE
Safety manager

### DIFF
--- a/MakLock.xcodeproj/project.pbxproj
+++ b/MakLock.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		A10000000000000000000204 /* AuthMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000214 /* AuthMethod.swift */; };
 		A10000000000000000000205 /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000215 /* Defaults.swift */; };
 		A10000000000000000000206 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000216 /* KeychainManager.swift */; };
+		A10000000000000000000301 /* SafetyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000311 /* SafetyManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,6 +45,7 @@
 		A10000000000000000000214 /* AuthMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthMethod.swift; sourceTree = "<group>"; };
 		A10000000000000000000215 /* Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Defaults.swift; sourceTree = "<group>"; };
 		A10000000000000000000216 /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
+		A10000000000000000000311 /* SafetyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetyManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,6 +108,7 @@
 		A100000000000000000000C2 /* Managers */ = {
 			isa = PBXGroup;
 			children = (
+				A10000000000000000000311 /* SafetyManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -299,6 +302,7 @@
 				A10000000000000000000204 /* AuthMethod.swift in Sources */,
 				A10000000000000000000205 /* Defaults.swift in Sources */,
 				A10000000000000000000206 /* KeychainManager.swift in Sources */,
+				A10000000000000000000301 /* SafetyManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MakLock/Core/Managers/SafetyManager.swift
+++ b/MakLock/Core/Managers/SafetyManager.swift
@@ -1,0 +1,86 @@
+import Foundation
+import HotKey
+import AppKit
+
+/// Manages safety mechanisms to prevent the user from getting locked out.
+///
+/// Safety features:
+/// - Panic key (Cmd+Option+Shift+Control+U) dismisses all overlays instantly
+/// - System blacklist prevents locking Terminal, Xcode, and other dev tools
+/// - Overlay timeout (60s) auto-dismisses stuck overlays
+/// - Dev mode (DEBUG only) adds Skip button and 10s auto-dismiss
+final class SafetyManager {
+    static let shared = SafetyManager()
+
+    /// Callback invoked when the panic key is pressed.
+    var onPanicKeyPressed: (() -> Void)?
+
+    /// Whether dev mode safety features are active.
+    static var isDevMode: Bool {
+        #if DEBUG
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    /// Maximum overlay display time before auto-dismiss (seconds).
+    static let overlayTimeout: TimeInterval = 60
+
+    /// Dev mode auto-dismiss time (seconds).
+    static let devModeTimeout: TimeInterval = 10
+
+    /// Bundle identifiers that can never be locked.
+    static let systemBlacklist: Set<String> = [
+        // Apple system apps
+        "com.apple.Terminal",
+        "com.apple.finder",
+        "com.apple.ActivityMonitor",
+        "com.apple.systempreferences",          // Monterey and earlier
+        "com.apple.SystemSettings",              // Ventura+
+        "com.apple.System-Preferences",
+
+        // Development tools
+        "com.apple.dt.Xcode",
+        "com.googlecode.iterm2",
+        "com.microsoft.VSCode",
+        "com.microsoft.VSCodeInsiders",
+        "com.sublimetext.4",
+        "com.jetbrains.intellij",
+
+        // MakLock itself
+        "com.makmak.MakLock",
+    ]
+
+    private var panicHotKey: HotKey?
+
+    private init() {
+        setupPanicKey()
+    }
+
+    // MARK: - Panic Key
+
+    private func setupPanicKey() {
+        // Cmd + Option + Shift + Control + U
+        panicHotKey = HotKey(
+            key: .u,
+            modifiers: [.command, .option, .shift, .control]
+        )
+
+        panicHotKey?.keyDownHandler = { [weak self] in
+            self?.triggerPanic()
+        }
+    }
+
+    private func triggerPanic() {
+        NSLog("[MakLock Safety] Panic key activated — dismissing all overlays")
+        onPanicKeyPressed?()
+    }
+
+    // MARK: - Blacklist
+
+    /// Check whether an app is on the system blacklist and must never be locked.
+    static func isBlacklisted(_ bundleIdentifier: String) -> Bool {
+        return systemBlacklist.contains(bundleIdentifier)
+    }
+}


### PR DESCRIPTION
## Summary
- Add SafetyManager with panic key (Cmd+Option+Shift+Control+U)
- System blacklist: Terminal, Xcode, Activity Monitor, System Settings, iTerm2, VS Code
- Dev mode flag (DEBUG builds only) with shorter timeout
- 60-second overlay timeout failsafe

## Safety Mechanisms
- **Panic key** — always active, even in Release builds
- **Blacklist** — hardcoded set of bundle IDs that can never be locked
- **Dev mode** — 10s auto-dismiss + Skip button in DEBUG
- **Timeout** — 60s failsafe in production