### PR TITLE
Menu bar

### DIFF
--- a/MakLock.xcodeproj/project.pbxproj
+++ b/MakLock.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		A10000000000000000000205 /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000215 /* Defaults.swift */; };
 		A10000000000000000000206 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000216 /* KeychainManager.swift */; };
 		A10000000000000000000301 /* SafetyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000311 /* SafetyManager.swift */; };
+		A10000000000000000000401 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000411 /* MenuBarController.swift */; };
+		A10000000000000000000402 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000412 /* AppDelegate.swift */; };
+		A10000000000000000000403 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000413 /* MenuBarView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -46,6 +49,9 @@
 		A10000000000000000000215 /* Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Defaults.swift; sourceTree = "<group>"; };
 		A10000000000000000000216 /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
 		A10000000000000000000311 /* SafetyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetyManager.swift; sourceTree = "<group>"; };
+		A10000000000000000000411 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
+		A10000000000000000000412 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		A10000000000000000000413 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -84,6 +90,7 @@
 			isa = PBXGroup;
 			children = (
 				A10000000000000000000011 /* MakLockApp.swift */,
+				A10000000000000000000412 /* AppDelegate.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -159,6 +166,8 @@
 		A100000000000000000000D3 /* MenuBar */ = {
 			isa = PBXGroup;
 			children = (
+				A10000000000000000000411 /* MenuBarController.swift */,
+				A10000000000000000000413 /* MenuBarView.swift */,
 			);
 			path = MenuBar;
 			sourceTree = "<group>";
@@ -303,6 +312,9 @@
 				A10000000000000000000205 /* Defaults.swift in Sources */,
 				A10000000000000000000206 /* KeychainManager.swift in Sources */,
 				A10000000000000000000301 /* SafetyManager.swift in Sources */,
+				A10000000000000000000401 /* MenuBarController.swift in Sources */,
+				A10000000000000000000402 /* AppDelegate.swift in Sources */,
+				A10000000000000000000403 /* MenuBarView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MakLock/App/AppDelegate.swift
+++ b/MakLock/App/AppDelegate.swift
@@ -1,0 +1,13 @@
+import AppKit
+
+/// Application delegate responsible for lifecycle and menu bar setup.
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    let menuBarController = MenuBarController()
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        menuBarController.setup()
+
+        // Initialize safety manager (registers panic key)
+        _ = SafetyManager.shared
+    }
+}

--- a/MakLock/App/MakLockApp.swift
+++ b/MakLock/App/MakLockApp.swift
@@ -2,17 +2,11 @@ import SwiftUI
 
 @main
 struct MakLockApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
     var body: some Scene {
-        MenuBarExtra("MakLock", systemImage: "lock") {
-            VStack {
-                Text("MakLock")
-                    .font(.headline)
-                Divider()
-                Button("Quit") {
-                    NSApplication.shared.terminate(nil)
-                }
-                .keyboardShortcut("q")
-            }
+        Settings {
+            EmptyView()
         }
     }
 }

--- a/MakLock/UI/MenuBar/MenuBarController.swift
+++ b/MakLock/UI/MenuBar/MenuBarController.swift
@@ -1,0 +1,79 @@
+import AppKit
+import SwiftUI
+
+/// Manages the NSStatusItem and menu bar icon states.
+final class MenuBarController {
+    private var statusItem: NSStatusItem?
+    private var popover: NSPopover?
+
+    /// Current lock state displayed in the menu bar.
+    enum IconState {
+        /// No protected apps are running.
+        case idle
+        /// A protected app is running (unlocked).
+        case active
+        /// An overlay is currently displayed.
+        case locked
+    }
+
+    var iconState: IconState = .idle {
+        didSet { updateIcon() }
+    }
+
+    func setup() {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        updateIcon()
+
+        let popover = NSPopover()
+        popover.contentSize = NSSize(width: 260, height: 200)
+        popover.behavior = .transient
+        popover.contentViewController = NSHostingController(rootView: MenuBarView(
+            onSettingsClicked: { [weak self] in
+                self?.hidePopover()
+                NotificationCenter.default.post(name: .openSettings, object: nil)
+            },
+            onQuitClicked: {
+                NSApplication.shared.terminate(nil)
+            }
+        ))
+        self.popover = popover
+
+        if let button = statusItem?.button {
+            button.action = #selector(togglePopover(_:))
+            button.target = self
+        }
+    }
+
+    @objc private func togglePopover(_ sender: Any?) {
+        guard let button = statusItem?.button else { return }
+        if let popover, popover.isShown {
+            hidePopover()
+        } else {
+            popover?.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        }
+    }
+
+    private func hidePopover() {
+        popover?.performClose(nil)
+    }
+
+    private func updateIcon() {
+        guard let button = statusItem?.button else { return }
+        let symbolName: String
+        switch iconState {
+        case .idle:
+            symbolName = "lock"
+        case .active:
+            symbolName = "lock.fill"
+        case .locked:
+            symbolName = "lock.fill"
+        }
+        button.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: "MakLock")
+    }
+}
+
+// MARK: - Notification Names
+
+extension Notification.Name {
+    static let openSettings = Notification.Name("com.makmak.MakLock.openSettings")
+}

--- a/MakLock/UI/MenuBar/MenuBarView.swift
+++ b/MakLock/UI/MenuBar/MenuBarView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+/// SwiftUI content for the menu bar popover dropdown.
+struct MenuBarView: View {
+    let onSettingsClicked: () -> Void
+    let onQuitClicked: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(MakLockColors.gold)
+                Text("MakLock")
+                    .font(MakLockTypography.headline)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 14)
+            .padding(.bottom, 10)
+
+            Divider()
+                .padding(.horizontal, 8)
+
+            // Status
+            HStack {
+                Circle()
+                    .fill(MakLockColors.success)
+                    .frame(width: 8, height: 8)
+                Text("Protection Active")
+                    .font(MakLockTypography.body)
+                    .foregroundColor(.secondary)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+
+            Divider()
+                .padding(.horizontal, 8)
+
+            // Actions
+            MenuBarButton(title: "Settings...", icon: "gearshape") {
+                onSettingsClicked()
+            }
+
+            Divider()
+                .padding(.horizontal, 8)
+
+            MenuBarButton(title: "Quit MakLock", icon: "power") {
+                onQuitClicked()
+            }
+
+            Spacer()
+                .frame(height: 8)
+        }
+        .frame(width: 260)
+    }
+}
+
+// MARK: - Menu Bar Button
+
+private struct MenuBarButton: View {
+    let title: String
+    let icon: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                Image(systemName: icon)
+                    .font(.system(size: 12))
+                    .frame(width: 16)
+                Text(title)
+                    .font(MakLockTypography.body)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}


### PR DESCRIPTION
## Summary
- Add MenuBarController with NSStatusItem and lock icon states (idle/active/locked)
- Add AppDelegate with menu bar and safety manager initialization
- Add MenuBarView with status indicator, Settings, and Quit actions
- Refactor MakLockApp to use NSApplicationDelegateAdaptor

## Menu Bar States
- `lock` (outline) — idle, no protected apps running
- `lock.fill` — a protected app is active
- `lock.fill` — overlay is displayed