### PR TITLE
Settings window

### DIFF
--- a/MakLock.xcodeproj/project.pbxproj
+++ b/MakLock.xcodeproj/project.pbxproj
@@ -27,6 +27,12 @@
 		A10000000000000000000401 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000411 /* MenuBarController.swift */; };
 		A10000000000000000000402 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000412 /* AppDelegate.swift */; };
 		A10000000000000000000403 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000413 /* MenuBarView.swift */; };
+		A10000000000000000000501 /* SettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000511 /* SettingsWindow.swift */; };
+		A10000000000000000000502 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000512 /* SettingsView.swift */; };
+		A10000000000000000000503 /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000513 /* GeneralSettingsView.swift */; };
+		A10000000000000000000504 /* AppsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000514 /* AppsSettingsView.swift */; };
+		A10000000000000000000505 /* SecuritySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000515 /* SecuritySettingsView.swift */; };
+		A10000000000000000000506 /* WatchSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000516 /* WatchSettingsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -52,6 +58,12 @@
 		A10000000000000000000411 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
 		A10000000000000000000412 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A10000000000000000000413 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
+		A10000000000000000000511 /* SettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindow.swift; sourceTree = "<group>"; };
+		A10000000000000000000512 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		A10000000000000000000513 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
+		A10000000000000000000514 /* AppsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppsSettingsView.swift; sourceTree = "<group>"; };
+		A10000000000000000000515 /* SecuritySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecuritySettingsView.swift; sourceTree = "<group>"; };
+		A10000000000000000000516 /* WatchSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchSettingsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -175,6 +187,12 @@
 		A100000000000000000000D4 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				A10000000000000000000511 /* SettingsWindow.swift */,
+				A10000000000000000000512 /* SettingsView.swift */,
+				A10000000000000000000513 /* GeneralSettingsView.swift */,
+				A10000000000000000000514 /* AppsSettingsView.swift */,
+				A10000000000000000000515 /* SecuritySettingsView.swift */,
+				A10000000000000000000516 /* WatchSettingsView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -315,6 +333,12 @@
 				A10000000000000000000401 /* MenuBarController.swift in Sources */,
 				A10000000000000000000402 /* AppDelegate.swift in Sources */,
 				A10000000000000000000403 /* MenuBarView.swift in Sources */,
+				A10000000000000000000501 /* SettingsWindow.swift in Sources */,
+				A10000000000000000000502 /* SettingsView.swift in Sources */,
+				A10000000000000000000503 /* GeneralSettingsView.swift in Sources */,
+				A10000000000000000000504 /* AppsSettingsView.swift in Sources */,
+				A10000000000000000000505 /* SecuritySettingsView.swift in Sources */,
+				A10000000000000000000506 /* WatchSettingsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MakLock/App/AppDelegate.swift
+++ b/MakLock/App/AppDelegate.swift
@@ -9,5 +9,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Initialize safety manager (registers panic key)
         _ = SafetyManager.shared
+
+        // Initialize settings window controller (listens for openSettings notification)
+        _ = SettingsWindowController.shared
     }
 }

--- a/MakLock/UI/Settings/AppsSettingsView.swift
+++ b/MakLock/UI/Settings/AppsSettingsView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+/// Apps settings tab: manage the list of protected applications.
+struct AppsSettingsView: View {
+    @State private var protectedApps: [ProtectedApp] = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Protected Applications")
+                .font(MakLockTypography.title)
+
+            if protectedApps.isEmpty {
+                emptyState
+            } else {
+                appsList
+            }
+
+            Spacer()
+
+            HStack {
+                Spacer()
+                PrimaryButton("Add App", icon: "plus") {
+                    // App picker will be connected in Task 8
+                }
+            }
+        }
+        .padding()
+        .onAppear {
+            protectedApps = Defaults.shared.protectedApps
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Spacer()
+            Image(systemName: "lock.open")
+                .font(.system(size: 40))
+                .foregroundColor(MakLockColors.textSecondary)
+            Text("No protected apps yet")
+                .font(MakLockTypography.headline)
+                .foregroundColor(.secondary)
+            Text("Add apps to protect them with Touch ID or password.")
+                .font(MakLockTypography.caption)
+                .foregroundColor(.secondary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var appsList: some View {
+        List {
+            ForEach($protectedApps) { $app in
+                HStack(spacing: 12) {
+                    AppIconView(bundleIdentifier: app.bundleIdentifier, size: 32)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(app.name)
+                            .font(MakLockTypography.headline)
+                        Text(app.bundleIdentifier)
+                            .font(MakLockTypography.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    Spacer()
+                    Toggle("", isOn: $app.isEnabled)
+                        .toggleStyle(.switch)
+                }
+                .padding(.vertical, 4)
+            }
+            .onDelete { indexSet in
+                protectedApps.remove(atOffsets: indexSet)
+                Defaults.shared.protectedApps = protectedApps
+            }
+        }
+    }
+}

--- a/MakLock/UI/Settings/GeneralSettingsView.swift
+++ b/MakLock/UI/Settings/GeneralSettingsView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// General settings tab: launch at login, idle auto-lock, sleep auto-lock.
+struct GeneralSettingsView: View {
+    @State private var launchAtLogin = false
+    @State private var lockOnSleep = true
+    @State private var lockOnIdle = false
+    @State private var idleTimeout = 5.0
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Launch MakLock at login", isOn: $launchAtLogin)
+
+                Toggle("Lock apps when Mac sleeps", isOn: $lockOnSleep)
+            }
+
+            Section {
+                Toggle("Lock apps after idle timeout", isOn: $lockOnIdle)
+
+                if lockOnIdle {
+                    HStack {
+                        Text("Timeout:")
+                        Slider(value: $idleTimeout, in: 1...30, step: 1)
+                        Text("\(Int(idleTimeout)) min")
+                            .frame(width: 50, alignment: .trailing)
+                            .monospacedDigit()
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
+    }
+}

--- a/MakLock/UI/Settings/SecuritySettingsView.swift
+++ b/MakLock/UI/Settings/SecuritySettingsView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+/// Security settings tab: authentication method, backup password.
+struct SecuritySettingsView: View {
+    @State private var requireAuthOnLaunch = true
+    @State private var hasBackupPassword = false
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Require authentication on app launch", isOn: $requireAuthOnLaunch)
+            }
+
+            Section("Backup Password") {
+                if hasBackupPassword {
+                    HStack {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(MakLockColors.success)
+                        Text("Backup password is set")
+                            .font(MakLockTypography.body)
+                    }
+
+                    Button("Change Password...") {
+                        // Password setup will be connected in Task 10
+                    }
+                } else {
+                    HStack {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundColor(MakLockColors.locked)
+                        Text("No backup password set")
+                            .font(MakLockTypography.body)
+                    }
+
+                    Button("Set Password...") {
+                        // Password setup will be connected in Task 10
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
+        .onAppear {
+            hasBackupPassword = KeychainManager.shared.hasPassword()
+        }
+    }
+}

--- a/MakLock/UI/Settings/SettingsView.swift
+++ b/MakLock/UI/Settings/SettingsView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// Root settings view with tabbed navigation.
+struct SettingsView: View {
+    var body: some View {
+        TabView {
+            GeneralSettingsView()
+                .tabItem {
+                    Label("General", systemImage: "gearshape")
+                }
+
+            AppsSettingsView()
+                .tabItem {
+                    Label("Apps", systemImage: "square.grid.2x2")
+                }
+
+            SecuritySettingsView()
+                .tabItem {
+                    Label("Security", systemImage: "lock.shield")
+                }
+
+            WatchSettingsView()
+                .tabItem {
+                    Label("Watch", systemImage: "applewatch")
+                }
+        }
+        .frame(width: 520, height: 400)
+    }
+}

--- a/MakLock/UI/Settings/SettingsWindow.swift
+++ b/MakLock/UI/Settings/SettingsWindow.swift
@@ -1,0 +1,44 @@
+import AppKit
+import SwiftUI
+
+/// Manages the Settings window lifecycle.
+final class SettingsWindowController {
+    static let shared = SettingsWindowController()
+
+    private var window: NSWindow?
+
+    private init() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(openSettings),
+            name: .openSettings,
+            object: nil
+        )
+    }
+
+    @objc func openSettings() {
+        if let window {
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let settingsView = SettingsView()
+        let hostingController = NSHostingController(rootView: settingsView)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 440),
+            styleMask: [.titled, .closable, .miniaturizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "MakLock Settings"
+        window.contentViewController = hostingController
+        window.center()
+        window.isReleasedWhenClosed = false
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        self.window = window
+    }
+}

--- a/MakLock/UI/Settings/WatchSettingsView.swift
+++ b/MakLock/UI/Settings/WatchSettingsView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// Watch settings tab: Apple Watch proximity unlock.
+struct WatchSettingsView: View {
+    @State private var useWatchUnlock = false
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Use Apple Watch to unlock", isOn: $useWatchUnlock)
+
+                if useWatchUnlock {
+                    HStack {
+                        Image(systemName: "applewatch.radiowaves.left.and.right")
+                            .font(.system(size: 24))
+                            .foregroundColor(MakLockColors.info)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Searching for Apple Watch...")
+                                .font(MakLockTypography.body)
+                            Text("Make sure Bluetooth is on and your Watch is nearby.")
+                                .font(MakLockTypography.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+
+            Section("How it works") {
+                Text("When your Apple Watch is nearby, MakLock can automatically unlock protected apps without requiring Touch ID or a password.")
+                    .font(MakLockTypography.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
+    }
+}


### PR DESCRIPTION
## Summary
- Add SettingsWindowController with NSWindow management
- Add tabbed SettingsView with 4 tabs: General, Apps, Security, Watch
- General: launch at login, lock on sleep, idle auto-lock with timeout slider
- Apps: protected apps list with toggle, empty state, Add App button (placeholder)
- Security: auth on launch toggle, backup password status
- Watch: Apple Watch proximity unlock toggle with status

## Integration
- Settings window opens from menu bar dropdown
- SettingsWindowController listens for openSettings notification