### PR TITLE
App monitoring

### DIFF
--- a/MakLock.xcodeproj/project.pbxproj
+++ b/MakLock.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		A10000000000000000000504 /* AppsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000514 /* AppsSettingsView.swift */; };
 		A10000000000000000000505 /* SecuritySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000515 /* SecuritySettingsView.swift */; };
 		A10000000000000000000506 /* WatchSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000516 /* WatchSettingsView.swift */; };
+		A10000000000000000000601 /* AppMonitorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000611 /* AppMonitorService.swift */; };
+		A10000000000000000000602 /* ProtectedAppsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000612 /* ProtectedAppsManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -64,6 +66,8 @@
 		A10000000000000000000514 /* AppsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppsSettingsView.swift; sourceTree = "<group>"; };
 		A10000000000000000000515 /* SecuritySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecuritySettingsView.swift; sourceTree = "<group>"; };
 		A10000000000000000000516 /* WatchSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchSettingsView.swift; sourceTree = "<group>"; };
+		A10000000000000000000611 /* AppMonitorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMonitorService.swift; sourceTree = "<group>"; };
+		A10000000000000000000612 /* ProtectedAppsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectedAppsManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -120,6 +124,7 @@
 		A100000000000000000000C1 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				A10000000000000000000611 /* AppMonitorService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -128,6 +133,7 @@
 			isa = PBXGroup;
 			children = (
 				A10000000000000000000311 /* SafetyManager.swift */,
+				A10000000000000000000612 /* ProtectedAppsManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -339,6 +345,8 @@
 				A10000000000000000000504 /* AppsSettingsView.swift in Sources */,
 				A10000000000000000000505 /* SecuritySettingsView.swift in Sources */,
 				A10000000000000000000506 /* WatchSettingsView.swift in Sources */,
+				A10000000000000000000601 /* AppMonitorService.swift in Sources */,
+				A10000000000000000000602 /* ProtectedAppsManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MakLock/Core/Managers/ProtectedAppsManager.swift
+++ b/MakLock/Core/Managers/ProtectedAppsManager.swift
@@ -1,0 +1,59 @@
+import AppKit
+import Combine
+
+/// Manages the list of protected applications with CRUD operations and persistence.
+final class ProtectedAppsManager: ObservableObject {
+    static let shared = ProtectedAppsManager()
+
+    @Published private(set) var apps: [ProtectedApp] = []
+
+    private init() {
+        apps = Defaults.shared.protectedApps
+    }
+
+    /// Add an application to the protected list.
+    func addApp(bundleIdentifier: String, name: String, path: String) {
+        guard !apps.contains(where: { $0.bundleIdentifier == bundleIdentifier }) else { return }
+
+        let app = ProtectedApp(
+            bundleIdentifier: bundleIdentifier,
+            name: name,
+            path: path
+        )
+        apps.append(app)
+        save()
+        NSLog("[MakLock] Added protected app: %@ (%@)", name, bundleIdentifier)
+    }
+
+    /// Add an app from an NSRunningApplication.
+    func addApp(from runningApp: NSRunningApplication) {
+        guard let bundleID = runningApp.bundleIdentifier,
+              let name = runningApp.localizedName,
+              let url = runningApp.bundleURL else { return }
+
+        addApp(bundleIdentifier: bundleID, name: name, path: url.path)
+    }
+
+    /// Remove an application from the protected list.
+    func removeApp(_ app: ProtectedApp) {
+        apps.removeAll { $0.id == app.id }
+        save()
+        NSLog("[MakLock] Removed protected app: %@", app.name)
+    }
+
+    /// Toggle protection on or off for an app.
+    func toggleApp(_ app: ProtectedApp) {
+        guard let index = apps.firstIndex(where: { $0.id == app.id }) else { return }
+        apps[index].isEnabled.toggle()
+        save()
+    }
+
+    /// Check whether an app with the given bundle identifier is protected and enabled.
+    func isProtected(_ bundleIdentifier: String) -> Bool {
+        return apps.contains { $0.bundleIdentifier == bundleIdentifier && $0.isEnabled }
+    }
+
+    private func save() {
+        Defaults.shared.protectedApps = apps
+    }
+}

--- a/MakLock/Core/Services/AppMonitorService.swift
+++ b/MakLock/Core/Services/AppMonitorService.swift
@@ -1,0 +1,67 @@
+import AppKit
+import Combine
+
+/// Monitors app launches and activations to detect when a protected app starts.
+final class AppMonitorService: ObservableObject {
+    static let shared = AppMonitorService()
+
+    /// Published when a protected app is launched or activated.
+    @Published var detectedApp: ProtectedApp?
+
+    /// Callback invoked when a protected app is detected.
+    var onProtectedAppDetected: ((ProtectedApp) -> Void)?
+
+    private var cancellables = Set<AnyCancellable>()
+
+    private init() {}
+
+    /// Start monitoring app launches and activations.
+    func startMonitoring() {
+        let workspace = NSWorkspace.shared
+
+        // Monitor app launches
+        workspace.notificationCenter.publisher(for: NSWorkspace.didLaunchApplicationNotification)
+            .compactMap { $0.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication }
+            .sink { [weak self] app in
+                self?.handleAppEvent(app)
+            }
+            .store(in: &cancellables)
+
+        // Monitor app activations (switching to a running protected app)
+        workspace.notificationCenter.publisher(for: NSWorkspace.didActivateApplicationNotification)
+            .compactMap { $0.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication }
+            .sink { [weak self] app in
+                self?.handleAppEvent(app)
+            }
+            .store(in: &cancellables)
+
+        NSLog("[MakLock] App monitor started")
+    }
+
+    /// Stop monitoring.
+    func stopMonitoring() {
+        cancellables.removeAll()
+        NSLog("[MakLock] App monitor stopped")
+    }
+
+    private func handleAppEvent(_ runningApp: NSRunningApplication) {
+        guard let bundleID = runningApp.bundleIdentifier else { return }
+
+        // Skip blacklisted system apps
+        guard !SafetyManager.isBlacklisted(bundleID) else { return }
+
+        // Check if this app is in the protected list
+        let protectedApps = Defaults.shared.protectedApps
+        guard let protectedApp = protectedApps.first(where: {
+            $0.bundleIdentifier == bundleID && $0.isEnabled
+        }) else { return }
+
+        // Check if global protection is enabled
+        let settings = Defaults.shared.appSettings
+        guard settings.isProtectionEnabled else { return }
+
+        NSLog("[MakLock] Protected app detected: %@ (%@)", protectedApp.name, bundleID)
+        detectedApp = protectedApp
+        onProtectedAppDetected?(protectedApp)
+    }
+}


### PR DESCRIPTION
## Summary
- Add AppMonitorService with NSWorkspace launch and activation detection
- Add ProtectedAppsManager with CRUD operations and UserDefaults persistence
- Logging only — no blocking yet (overlay integration in Task 9)

## How It Works
- Listens for `didLaunchApplicationNotification` and `didActivateApplicationNotification`
- Filters by bundle identifier against the protected apps list
- Checks system blacklist (SafetyManager) before triggering
- Publishes detected app via Combine for downstream consumers