### PR TITLE
Lock overlay

### DIFF
--- a/MakLock.xcodeproj/project.pbxproj
+++ b/MakLock.xcodeproj/project.pbxproj
@@ -37,6 +37,9 @@
 		A10000000000000000000602 /* ProtectedAppsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000612 /* ProtectedAppsManager.swift */; };
 		A10000000000000000000701 /* AppPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000711 /* AppPickerView.swift */; };
 		A10000000000000000000702 /* AppPickerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000712 /* AppPickerWindow.swift */; };
+		A10000000000000000000801 /* LockOverlayWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000811 /* LockOverlayWindow.swift */; };
+		A10000000000000000000802 /* LockOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000812 /* LockOverlayView.swift */; };
+		A10000000000000000000803 /* OverlayWindowService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000813 /* OverlayWindowService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -72,6 +75,9 @@
 		A10000000000000000000612 /* ProtectedAppsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectedAppsManager.swift; sourceTree = "<group>"; };
 		A10000000000000000000711 /* AppPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPickerView.swift; sourceTree = "<group>"; };
 		A10000000000000000000712 /* AppPickerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPickerWindow.swift; sourceTree = "<group>"; };
+		A10000000000000000000811 /* LockOverlayWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockOverlayWindow.swift; sourceTree = "<group>"; };
+		A10000000000000000000812 /* LockOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockOverlayView.swift; sourceTree = "<group>"; };
+		A10000000000000000000813 /* OverlayWindowService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayWindowService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -129,6 +135,7 @@
 			isa = PBXGroup;
 			children = (
 				A10000000000000000000611 /* AppMonitorService.swift */,
+				A10000000000000000000813 /* OverlayWindowService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -210,6 +217,8 @@
 		A100000000000000000000D5 /* LockOverlay */ = {
 			isa = PBXGroup;
 			children = (
+				A10000000000000000000811 /* LockOverlayWindow.swift */,
+				A10000000000000000000812 /* LockOverlayView.swift */,
 			);
 			path = LockOverlay;
 			sourceTree = "<group>";
@@ -355,6 +364,9 @@
 				A10000000000000000000602 /* ProtectedAppsManager.swift in Sources */,
 			A10000000000000000000701 /* AppPickerView.swift in Sources */,
 			A10000000000000000000702 /* AppPickerWindow.swift in Sources */,
+				A10000000000000000000801 /* LockOverlayWindow.swift in Sources */,
+				A10000000000000000000802 /* LockOverlayView.swift in Sources */,
+				A10000000000000000000803 /* OverlayWindowService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MakLock/App/AppDelegate.swift
+++ b/MakLock/App/AppDelegate.swift
@@ -8,21 +8,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         menuBarController.setup()
 
         // Initialize safety manager and wire up panic key
-        SafetyManager.shared.onPanicKeyPressed = {
+        SafetyManager.shared.onPanicKeyPressed = { [weak self] in
             OverlayWindowService.shared.dismissAll()
+            self?.menuBarController.iconState = .idle
         }
 
         // Initialize settings window controller (listens for openSettings notification)
         _ = SettingsWindowController.shared
 
         // Wire up app monitor → overlay
-        AppMonitorService.shared.onProtectedAppDetected = { app in
+        AppMonitorService.shared.onProtectedAppDetected = { [weak self] app in
             OverlayWindowService.shared.show(for: app)
+            self?.menuBarController.iconState = .locked
         }
 
-        // For now, unlock just hides the overlay (auth service comes in Task 10)
-        OverlayWindowService.shared.onUnlockRequested = { _ in
+        // Unlock hides the overlay (auth service comes in Task 10)
+        OverlayWindowService.shared.onUnlockRequested = { [weak self] _ in
             OverlayWindowService.shared.hide()
+            self?.menuBarController.iconState = .active
         }
 
         // Start monitoring

--- a/MakLock/App/AppDelegate.swift
+++ b/MakLock/App/AppDelegate.swift
@@ -7,10 +7,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         menuBarController.setup()
 
-        // Initialize safety manager (registers panic key)
-        _ = SafetyManager.shared
+        // Initialize safety manager and wire up panic key
+        SafetyManager.shared.onPanicKeyPressed = {
+            OverlayWindowService.shared.dismissAll()
+        }
 
         // Initialize settings window controller (listens for openSettings notification)
         _ = SettingsWindowController.shared
+
+        // Wire up app monitor → overlay
+        AppMonitorService.shared.onProtectedAppDetected = { app in
+            OverlayWindowService.shared.show(for: app)
+        }
+
+        // For now, unlock just hides the overlay (auth service comes in Task 10)
+        OverlayWindowService.shared.onUnlockRequested = { _ in
+            OverlayWindowService.shared.hide()
+        }
+
+        // Start monitoring
+        AppMonitorService.shared.startMonitoring()
     }
 }

--- a/MakLock/Core/Services/OverlayWindowService.swift
+++ b/MakLock/Core/Services/OverlayWindowService.swift
@@ -1,0 +1,94 @@
+import AppKit
+import SwiftUI
+
+/// Manages overlay window lifecycle: show, hide, and timeout failsafe.
+final class OverlayWindowService {
+    static let shared = OverlayWindowService()
+
+    private var overlayWindows: [LockOverlayWindow] = []
+    private var timeoutTimer: Timer?
+    private var currentApp: ProtectedApp?
+
+    /// Callback when the user requests unlock (Touch ID or password).
+    var onUnlockRequested: ((ProtectedApp) -> Void)?
+
+    /// Callback when the user requests password input.
+    var onPasswordRequested: ((ProtectedApp) -> Void)?
+
+    private init() {}
+
+    /// Show the lock overlay for a protected app on all screens.
+    func show(for app: ProtectedApp) {
+        // Don't show duplicate overlays
+        guard overlayWindows.isEmpty else { return }
+
+        currentApp = app
+
+        for screen in NSScreen.screens {
+            let window = LockOverlayWindow(for: screen)
+
+            let overlayView = LockOverlayView(
+                appName: app.name,
+                bundleIdentifier: app.bundleIdentifier,
+                onUnlock: { [weak self] in
+                    self?.handleUnlock()
+                },
+                onUsePassword: { [weak self] in
+                    guard let self, let app = self.currentApp else { return }
+                    self.onPasswordRequested?(app)
+                }
+            )
+
+            window.contentView = NSHostingView(rootView: overlayView)
+            window.makeKeyAndOrderFront(nil)
+            overlayWindows.append(window)
+        }
+
+        startTimeoutTimer()
+        NSLog("[MakLock] Overlay shown for: %@", app.name)
+    }
+
+    /// Hide all overlay windows.
+    func hide() {
+        stopTimeoutTimer()
+        overlayWindows.forEach { $0.close() }
+        overlayWindows.removeAll()
+        currentApp = nil
+        NSLog("[MakLock] Overlay dismissed")
+    }
+
+    /// Dismiss all overlays (used by panic key).
+    func dismissAll() {
+        hide()
+    }
+
+    /// Whether an overlay is currently displayed.
+    var isShowing: Bool {
+        !overlayWindows.isEmpty
+    }
+
+    // MARK: - Timeout
+
+    private func startTimeoutTimer() {
+        let timeout = SafetyManager.isDevMode
+            ? SafetyManager.devModeTimeout
+            : SafetyManager.overlayTimeout
+
+        timeoutTimer = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) { [weak self] _ in
+            NSLog("[MakLock Safety] Overlay timeout reached (%.0fs) — auto-dismissing", timeout)
+            self?.hide()
+        }
+    }
+
+    private func stopTimeoutTimer() {
+        timeoutTimer?.invalidate()
+        timeoutTimer = nil
+    }
+
+    // MARK: - Private
+
+    private func handleUnlock() {
+        guard let app = currentApp else { return }
+        onUnlockRequested?(app)
+    }
+}

--- a/MakLock/UI/LockOverlay/LockOverlayView.swift
+++ b/MakLock/UI/LockOverlay/LockOverlayView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+/// The lock overlay UI: blur background with centered unlock card.
+struct LockOverlayView: View {
+    let appName: String
+    let bundleIdentifier: String
+    let onUnlock: () -> Void
+    let onUsePassword: () -> Void
+
+    @State private var isVisible = false
+
+    var body: some View {
+        ZStack {
+            // Blur background
+            BlurView(material: .hudWindow, blendingMode: .behindWindow)
+                .ignoresSafeArea()
+
+            // Dark tint
+            Color.black.opacity(0.4)
+                .ignoresSafeArea()
+
+            // Unlock card
+            VStack(spacing: 20) {
+                // App icon
+                AppIconView(bundleIdentifier: bundleIdentifier, size: 64)
+
+                // Title
+                Text("\(appName) is Locked")
+                    .font(MakLockTypography.largeTitle)
+                    .foregroundColor(MakLockColors.textPrimary)
+
+                Text("Use Touch ID to unlock")
+                    .font(MakLockTypography.body)
+                    .foregroundColor(MakLockColors.textSecondary)
+
+                // Unlock button
+                PrimaryButton("Unlock", icon: "touchid") {
+                    onUnlock()
+                }
+                .padding(.top, 4)
+
+                // Password fallback
+                SecondaryButton("Use Password Instead") {
+                    onUsePassword()
+                }
+
+                // Dev mode skip button
+                #if DEBUG
+                Button("Skip (Dev)") {
+                    onUnlock()
+                }
+                .font(MakLockTypography.caption)
+                .foregroundColor(MakLockColors.error)
+                .padding(.top, 8)
+                #endif
+            }
+            .padding(40)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(MakLockColors.cardDark)
+                    .shadow(color: .black.opacity(0.3), radius: 20, y: 8)
+            )
+            .scaleEffect(isVisible ? 1.0 : 0.9)
+            .opacity(isVisible ? 1.0 : 0.0)
+        }
+        .onAppear {
+            withAnimation(MakLockAnimations.overlayAppear) {
+                isVisible = true
+            }
+        }
+    }
+
+    /// Animate the overlay disappearing.
+    func animateDisappear(completion: @escaping () -> Void) {
+        withAnimation(MakLockAnimations.overlayDisappear) {
+            isVisible = false
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            completion()
+        }
+    }
+}

--- a/MakLock/UI/LockOverlay/LockOverlayWindow.swift
+++ b/MakLock/UI/LockOverlay/LockOverlayWindow.swift
@@ -1,0 +1,21 @@
+import AppKit
+
+/// Full-screen overlay window that blocks interaction with a protected app.
+final class LockOverlayWindow: NSWindow {
+    init(for screen: NSScreen) {
+        super.init(
+            contentRect: screen.frame,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+
+        self.level = .screenSaver
+        self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        self.isOpaque = false
+        self.backgroundColor = .clear
+        self.ignoresMouseEvents = false
+        self.hasShadow = false
+        self.isReleasedWhenClosed = false
+    }
+}


### PR DESCRIPTION
## Summary
- Add LockOverlayWindow (NSWindow, level .screenSaver, borderless, all spaces)
- Add LockOverlayView with blur background, dark tint, and centered unlock card
- Add OverlayWindowService with show/hide, multi-monitor, and timeout failsafe
- Wire overlay to app monitor: show when a protected app launches
- Update menu bar icon state on lock/unlock
- Dev mode: Skip button visible in DEBUG builds, 10s auto-dismiss

## Safety
- Panic key (Cmd+Opt+Shift+Ctrl+U) dismisses all overlays
- 60s timeout failsafe (10s in dev mode)
- System blacklist prevents locking Terminal, Xcode, etc.