### PR TITLE
Idle auto-lock

### DIFF
--- a/MakLock.xcodeproj/project.pbxproj
+++ b/MakLock.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		A10000000000000000000803 /* OverlayWindowService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000813 /* OverlayWindowService.swift */; };
 		A10000000000000000000901 /* AuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000911 /* AuthenticationService.swift */; };
 		A10000000000000000000902 /* PasswordInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000912 /* PasswordInputView.swift */; };
+		A10000000000000000000A01 /* IdleMonitorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000A11 /* IdleMonitorService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -82,6 +83,7 @@
 		A10000000000000000000813 /* OverlayWindowService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayWindowService.swift; sourceTree = "<group>"; };
 		A10000000000000000000911 /* AuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationService.swift; sourceTree = "<group>"; };
 		A10000000000000000000912 /* PasswordInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordInputView.swift; sourceTree = "<group>"; };
+		A10000000000000000000A11 /* IdleMonitorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleMonitorService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -141,6 +143,7 @@
 				A10000000000000000000611 /* AppMonitorService.swift */,
 				A10000000000000000000813 /* OverlayWindowService.swift */,
 				A10000000000000000000911 /* AuthenticationService.swift */,
+				A10000000000000000000A11 /* IdleMonitorService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -375,6 +378,7 @@
 				A10000000000000000000803 /* OverlayWindowService.swift in Sources */,
 				A10000000000000000000901 /* AuthenticationService.swift in Sources */,
 				A10000000000000000000902 /* PasswordInputView.swift in Sources */,
+				A10000000000000000000A01 /* IdleMonitorService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MakLock/App/AppDelegate.swift
+++ b/MakLock/App/AppDelegate.swift
@@ -48,7 +48,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             _ = self
         }
 
-        // Start monitoring
+        // Start app monitoring
         AppMonitorService.shared.startMonitoring()
+
+        // Wire up idle monitor → lock all protected apps
+        IdleMonitorService.shared.onIdleTimeoutReached = { [weak self] in
+            guard let self else { return }
+            let apps = ProtectedAppsManager.shared.apps.filter(\.isEnabled)
+            for app in apps {
+                OverlayWindowService.shared.show(for: app)
+            }
+            if !apps.isEmpty {
+                self.menuBarController.iconState = .locked
+            }
+        }
+
+        // Start idle monitoring if enabled
+        if Defaults.shared.appSettings.lockOnIdle {
+            IdleMonitorService.shared.startMonitoring()
+        }
     }
 }

--- a/MakLock/Core/Services/IdleMonitorService.swift
+++ b/MakLock/Core/Services/IdleMonitorService.swift
@@ -1,0 +1,79 @@
+import Foundation
+import IOKit
+
+/// Monitors system idle time and triggers auto-lock when the threshold is exceeded.
+final class IdleMonitorService {
+    static let shared = IdleMonitorService()
+
+    /// Callback when idle timeout is reached.
+    var onIdleTimeoutReached: (() -> Void)?
+
+    private var timer: Timer?
+    private let checkInterval: TimeInterval = 10
+
+    private init() {}
+
+    /// Start monitoring idle time with the given timeout in minutes.
+    func startMonitoring() {
+        stopMonitoring()
+
+        timer = Timer.scheduledTimer(withTimeInterval: checkInterval, repeats: true) { [weak self] _ in
+            self?.checkIdleTime()
+        }
+
+        NSLog("[MakLock] Idle monitor started")
+    }
+
+    /// Stop monitoring.
+    func stopMonitoring() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    /// Whether monitoring is active.
+    var isMonitoring: Bool {
+        timer != nil
+    }
+
+    // MARK: - Private
+
+    private func checkIdleTime() {
+        let settings = Defaults.shared.appSettings
+        guard settings.lockOnIdle else { return }
+
+        let timeoutSeconds = TimeInterval(settings.idleTimeoutMinutes) * 60
+        let idleSeconds = systemIdleTime()
+
+        if idleSeconds >= timeoutSeconds {
+            NSLog("[MakLock] Idle timeout reached (%.0fs idle, %.0fs threshold)", idleSeconds, timeoutSeconds)
+            onIdleTimeoutReached?()
+        }
+    }
+
+    /// Get system idle time in seconds using IOKit HIDIdleTime.
+    private func systemIdleTime() -> TimeInterval {
+        var iterator: io_iterator_t = 0
+        let result = IOServiceGetMatchingServices(
+            kIOMainPortDefault,
+            IOServiceMatching("IOHIDSystem"),
+            &iterator
+        )
+
+        guard result == KERN_SUCCESS else { return 0 }
+        defer { IOObjectRelease(iterator) }
+
+        let entry = IOIteratorNext(iterator)
+        guard entry != 0 else { return 0 }
+        defer { IOObjectRelease(entry) }
+
+        var unmanagedDict: Unmanaged<CFMutableDictionary>?
+        guard IORegistryEntryCreateCFProperties(entry, &unmanagedDict, kCFAllocatorDefault, 0) == KERN_SUCCESS,
+              let dict = unmanagedDict?.takeRetainedValue() as? [String: Any],
+              let idleTime = dict["HIDIdleTime"] as? Int64 else {
+            return 0
+        }
+
+        // HIDIdleTime is in nanoseconds
+        return TimeInterval(idleTime) / 1_000_000_000
+    }
+}

--- a/MakLock/UI/Settings/GeneralSettingsView.swift
+++ b/MakLock/UI/Settings/GeneralSettingsView.swift
@@ -2,27 +2,31 @@ import SwiftUI
 
 /// General settings tab: launch at login, idle auto-lock, sleep auto-lock.
 struct GeneralSettingsView: View {
-    @State private var launchAtLogin = false
-    @State private var lockOnSleep = true
-    @State private var lockOnIdle = false
-    @State private var idleTimeout = 5.0
+    @State private var settings = Defaults.shared.appSettings
 
     var body: some View {
         Form {
             Section {
-                Toggle("Launch MakLock at login", isOn: $launchAtLogin)
+                Toggle("Launch MakLock at login", isOn: $settings.launchAtLogin)
 
-                Toggle("Lock apps when Mac sleeps", isOn: $lockOnSleep)
+                Toggle("Lock apps when Mac sleeps", isOn: $settings.lockOnSleep)
             }
 
             Section {
-                Toggle("Lock apps after idle timeout", isOn: $lockOnIdle)
+                Toggle("Lock apps after idle timeout", isOn: $settings.lockOnIdle)
 
-                if lockOnIdle {
+                if settings.lockOnIdle {
                     HStack {
                         Text("Timeout:")
-                        Slider(value: $idleTimeout, in: 1...30, step: 1)
-                        Text("\(Int(idleTimeout)) min")
+                        Slider(
+                            value: Binding(
+                                get: { Double(settings.idleTimeoutMinutes) },
+                                set: { settings.idleTimeoutMinutes = Int($0) }
+                            ),
+                            in: 1...30,
+                            step: 1
+                        )
+                        Text("\(settings.idleTimeoutMinutes) min")
                             .frame(width: 50, alignment: .trailing)
                             .monospacedDigit()
                     }
@@ -31,5 +35,20 @@ struct GeneralSettingsView: View {
         }
         .formStyle(.grouped)
         .padding()
+        .onChange(of: settings.launchAtLogin) { _ in save() }
+        .onChange(of: settings.lockOnSleep) { _ in save() }
+        .onChange(of: settings.lockOnIdle) { _ in save() }
+        .onChange(of: settings.idleTimeoutMinutes) { _ in save() }
+    }
+
+    private func save() {
+        Defaults.shared.appSettings = settings
+
+        // Start or stop idle monitoring based on toggle
+        if settings.lockOnIdle {
+            IdleMonitorService.shared.startMonitoring()
+        } else {
+            IdleMonitorService.shared.stopMonitoring()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add IdleMonitorService using IOKit HIDIdleTime for system idle detection
- Wire idle settings in GeneralSettingsView to Defaults persistence
- Configurable timeout (1-30 minutes) with auto-lock on idle threshold
- Integrate idle monitor into AppDelegate lifecycle

## Changes
- `IdleMonitorService.swift` — polls HIDIdleTime every 10s, triggers callback on threshold
- `GeneralSettingsView.swift` — connected to Defaults, starts/stops idle monitor on toggle
- `AppDelegate.swift` — wires idle timeout to lock overlay for all enabled protected apps