### PR TITLE
Sleep/wake auto-lock

### DIFF
--- a/MakLock.xcodeproj/project.pbxproj
+++ b/MakLock.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		A10000000000000000000901 /* AuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000911 /* AuthenticationService.swift */; };
 		A10000000000000000000902 /* PasswordInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000912 /* PasswordInputView.swift */; };
 		A10000000000000000000A01 /* IdleMonitorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000A11 /* IdleMonitorService.swift */; };
+		A10000000000000000000B01 /* SleepWakeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000B11 /* SleepWakeService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -84,6 +85,7 @@
 		A10000000000000000000911 /* AuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationService.swift; sourceTree = "<group>"; };
 		A10000000000000000000912 /* PasswordInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordInputView.swift; sourceTree = "<group>"; };
 		A10000000000000000000A11 /* IdleMonitorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleMonitorService.swift; sourceTree = "<group>"; };
+		A10000000000000000000B11 /* SleepWakeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepWakeService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -144,6 +146,7 @@
 				A10000000000000000000813 /* OverlayWindowService.swift */,
 				A10000000000000000000911 /* AuthenticationService.swift */,
 				A10000000000000000000A11 /* IdleMonitorService.swift */,
+				A10000000000000000000B11 /* SleepWakeService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -379,6 +382,7 @@
 				A10000000000000000000901 /* AuthenticationService.swift in Sources */,
 				A10000000000000000000902 /* PasswordInputView.swift in Sources */,
 				A10000000000000000000A01 /* IdleMonitorService.swift in Sources */,
+				A10000000000000000000B01 /* SleepWakeService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MakLock/App/AppDelegate.swift
+++ b/MakLock/App/AppDelegate.swift
@@ -67,5 +67,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if Defaults.shared.appSettings.lockOnIdle {
             IdleMonitorService.shared.startMonitoring()
         }
+
+        // Wire up sleep/wake → lock all protected apps on sleep
+        SleepWakeService.shared.onSleep = { [weak self] in
+            guard let self else { return }
+            let apps = ProtectedAppsManager.shared.apps.filter(\.isEnabled)
+            for app in apps {
+                OverlayWindowService.shared.show(for: app)
+            }
+            if !apps.isEmpty {
+                self.menuBarController.iconState = .locked
+            }
+        }
+
+        // Start sleep/wake observer
+        SleepWakeService.shared.startObserving()
     }
 }

--- a/MakLock/Core/Services/SleepWakeService.swift
+++ b/MakLock/Core/Services/SleepWakeService.swift
@@ -1,0 +1,63 @@
+import Foundation
+import AppKit
+
+/// Monitors system sleep/wake events and triggers auto-lock on sleep.
+final class SleepWakeService {
+    static let shared = SleepWakeService()
+
+    /// Callback when the system is about to sleep.
+    var onSleep: (() -> Void)?
+
+    /// Callback when the system wakes from sleep.
+    var onWake: (() -> Void)?
+
+    private var isObserving = false
+
+    private init() {}
+
+    /// Begin observing sleep/wake notifications.
+    func startObserving() {
+        guard !isObserving else { return }
+        isObserving = true
+
+        let center = NSWorkspace.shared.notificationCenter
+
+        center.addObserver(
+            self,
+            selector: #selector(handleSleep),
+            name: NSWorkspace.willSleepNotification,
+            object: nil
+        )
+
+        center.addObserver(
+            self,
+            selector: #selector(handleWake),
+            name: NSWorkspace.didWakeNotification,
+            object: nil
+        )
+
+        NSLog("[MakLock] Sleep/wake observer started")
+    }
+
+    /// Stop observing sleep/wake notifications.
+    func stopObserving() {
+        guard isObserving else { return }
+        isObserving = false
+
+        NSWorkspace.shared.notificationCenter.removeObserver(self)
+        NSLog("[MakLock] Sleep/wake observer stopped")
+    }
+
+    // MARK: - Handlers
+
+    @objc private func handleSleep(_ notification: Notification) {
+        guard Defaults.shared.appSettings.lockOnSleep else { return }
+        NSLog("[MakLock] System going to sleep — triggering auto-lock")
+        onSleep?()
+    }
+
+    @objc private func handleWake(_ notification: Notification) {
+        NSLog("[MakLock] System woke from sleep")
+        onWake?()
+    }
+}


### PR DESCRIPTION
## Summary
- Add SleepWakeService using NSWorkspace sleep/wake notifications
- Wire sleep event to lock all enabled protected apps
- Lock on sleep toggle already persisted via GeneralSettingsView → Defaults

## Changes
- `SleepWakeService.swift` — observes willSleep/didWake, checks lockOnSleep setting
- `AppDelegate.swift` — wires sleep callback to show overlay for all protected apps