### PR TITLE
Watch proximity unlock

### DIFF
--- a/MakLock.xcodeproj/project.pbxproj
+++ b/MakLock.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		A10000000000000000000902 /* PasswordInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000912 /* PasswordInputView.swift */; };
 		A10000000000000000000A01 /* IdleMonitorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000A11 /* IdleMonitorService.swift */; };
 		A10000000000000000000B01 /* SleepWakeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000B11 /* SleepWakeService.swift */; };
+		A10000000000000000000C01 /* WatchProximityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000C11 /* WatchProximityService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -86,6 +87,7 @@
 		A10000000000000000000912 /* PasswordInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordInputView.swift; sourceTree = "<group>"; };
 		A10000000000000000000A11 /* IdleMonitorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleMonitorService.swift; sourceTree = "<group>"; };
 		A10000000000000000000B11 /* SleepWakeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepWakeService.swift; sourceTree = "<group>"; };
+		A10000000000000000000C11 /* WatchProximityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchProximityService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -147,6 +149,7 @@
 				A10000000000000000000911 /* AuthenticationService.swift */,
 				A10000000000000000000A11 /* IdleMonitorService.swift */,
 				A10000000000000000000B11 /* SleepWakeService.swift */,
+				A10000000000000000000C11 /* WatchProximityService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -383,6 +386,7 @@
 				A10000000000000000000902 /* PasswordInputView.swift in Sources */,
 				A10000000000000000000A01 /* IdleMonitorService.swift in Sources */,
 				A10000000000000000000B01 /* SleepWakeService.swift in Sources */,
+				A10000000000000000000C01 /* WatchProximityService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MakLock/Core/Services/WatchProximityService.swift
+++ b/MakLock/Core/Services/WatchProximityService.swift
@@ -1,0 +1,189 @@
+import Foundation
+import CoreBluetooth
+
+/// Monitors Apple Watch BLE proximity for auto-unlock.
+///
+/// When the paired Watch moves out of range (RSSI below threshold),
+/// the system triggers a lock. When it returns in range, auto-unlock fires.
+final class WatchProximityService: NSObject, ObservableObject {
+    static let shared = WatchProximityService()
+
+    /// Callback when the Watch moves out of BLE range.
+    var onWatchOutOfRange: (() -> Void)?
+
+    /// Callback when the Watch returns to BLE range.
+    var onWatchInRange: (() -> Void)?
+
+    /// Whether the Watch is currently detected in range.
+    @Published private(set) var isWatchInRange = false
+
+    /// Whether BLE scanning is active.
+    @Published private(set) var isScanning = false
+
+    /// The paired Watch peripheral identifier (persisted).
+    @Published var pairedWatchIdentifier: UUID? {
+        didSet {
+            if let id = pairedWatchIdentifier {
+                UserDefaults.standard.set(id.uuidString, forKey: "MakLock.pairedWatchID")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "MakLock.pairedWatchID")
+            }
+        }
+    }
+
+    /// RSSI threshold: values below this are considered "out of range".
+    /// Default: -70 dBm (roughly 2-3 meters).
+    var rssiThreshold: Int = -70
+
+    private var centralManager: CBCentralManager?
+    private var pairedPeripheral: CBPeripheral?
+    private var rssiTimer: Timer?
+
+    /// Number of consecutive out-of-range readings before triggering.
+    private let outOfRangeCount = 3
+    private var consecutiveOutOfRange = 0
+
+    private override init() {
+        super.init()
+
+        // Restore paired Watch ID
+        if let stored = UserDefaults.standard.string(forKey: "MakLock.pairedWatchID"),
+           let uuid = UUID(uuidString: stored) {
+            pairedWatchIdentifier = uuid
+        }
+    }
+
+    /// Start BLE scanning for the paired Watch.
+    func startScanning() {
+        guard !isScanning else { return }
+        centralManager = CBCentralManager(delegate: self, queue: nil)
+        isScanning = true
+        NSLog("[MakLock] Watch proximity scanning started")
+    }
+
+    /// Stop BLE scanning.
+    func stopScanning() {
+        rssiTimer?.invalidate()
+        rssiTimer = nil
+        centralManager?.stopScan()
+        centralManager = nil
+        pairedPeripheral = nil
+        isScanning = false
+        isWatchInRange = false
+        consecutiveOutOfRange = 0
+        NSLog("[MakLock] Watch proximity scanning stopped")
+    }
+
+    /// Unpair the current Watch.
+    func unpair() {
+        stopScanning()
+        pairedWatchIdentifier = nil
+        pairedPeripheral = nil
+        NSLog("[MakLock] Watch unpaired")
+    }
+
+    // MARK: - Private
+
+    private func startRSSIPolling() {
+        rssiTimer?.invalidate()
+        rssiTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
+            self?.pairedPeripheral?.readRSSI()
+        }
+    }
+
+    private func handleRSSI(_ rssi: Int) {
+        if rssi < rssiThreshold {
+            consecutiveOutOfRange += 1
+            if consecutiveOutOfRange >= outOfRangeCount && isWatchInRange {
+                isWatchInRange = false
+                NSLog("[MakLock] Watch out of range (RSSI: %d, threshold: %d)", rssi, rssiThreshold)
+                onWatchOutOfRange?()
+            }
+        } else {
+            let wasOutOfRange = !isWatchInRange
+            consecutiveOutOfRange = 0
+            isWatchInRange = true
+            if wasOutOfRange {
+                NSLog("[MakLock] Watch in range (RSSI: %d)", rssi)
+                onWatchInRange?()
+            }
+        }
+    }
+}
+
+// MARK: - CBCentralManagerDelegate
+
+extension WatchProximityService: CBCentralManagerDelegate {
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        guard central.state == .poweredOn else {
+            if central.state == .unauthorized {
+                NSLog("[MakLock] Bluetooth access not authorized")
+            }
+            return
+        }
+
+        // If we have a paired Watch, try to reconnect
+        if let watchID = pairedWatchIdentifier {
+            let peripherals = central.retrievePeripherals(withIdentifiers: [watchID])
+            if let peripheral = peripherals.first {
+                pairedPeripheral = peripheral
+                peripheral.delegate = self
+                central.connect(peripheral)
+                NSLog("[MakLock] Reconnecting to paired Watch: %@", watchID.uuidString)
+                return
+            }
+        }
+
+        // Otherwise scan for nearby devices
+        central.scanForPeripherals(withServices: nil, options: [
+            CBCentralManagerScanOptionAllowDuplicatesKey: true
+        ])
+        NSLog("[MakLock] Scanning for Watch peripherals")
+    }
+
+    func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral,
+                        advertisementData: [String: Any], rssi RSSI: NSNumber) {
+        // Look for Apple Watch by name prefix
+        guard let name = peripheral.name, name.contains("Apple Watch") else { return }
+
+        // If no Watch is paired, pair with the first one found
+        if pairedWatchIdentifier == nil {
+            pairedWatchIdentifier = peripheral.identifier
+            NSLog("[MakLock] Discovered Watch: %@ (ID: %@)", name, peripheral.identifier.uuidString)
+        }
+
+        guard peripheral.identifier == pairedWatchIdentifier else { return }
+
+        central.stopScan()
+        pairedPeripheral = peripheral
+        peripheral.delegate = self
+        central.connect(peripheral)
+    }
+
+    func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        NSLog("[MakLock] Connected to Watch: %@", peripheral.identifier.uuidString)
+        isWatchInRange = true
+        consecutiveOutOfRange = 0
+        startRSSIPolling()
+    }
+
+    func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+        NSLog("[MakLock] Watch disconnected")
+        isWatchInRange = false
+        rssiTimer?.invalidate()
+        rssiTimer = nil
+        onWatchOutOfRange?()
+
+        // Try to reconnect
+        central.connect(peripheral)
+    }
+}
+
+// MARK: - CBPeripheralDelegate
+
+extension WatchProximityService: CBPeripheralDelegate {
+    func peripheral(_ peripheral: CBPeripheral, didReadRSSI RSSI: NSNumber, error: Error?) {
+        guard error == nil else { return }
+        handleRSSI(RSSI.intValue)
+    }
+}

--- a/MakLock/UI/Settings/WatchSettingsView.swift
+++ b/MakLock/UI/Settings/WatchSettingsView.swift
@@ -1,38 +1,115 @@
 import SwiftUI
 
-/// Watch settings tab: Apple Watch proximity unlock.
+/// Watch settings tab: Apple Watch proximity unlock with pairing and sensitivity.
 struct WatchSettingsView: View {
-    @State private var useWatchUnlock = false
+    @ObservedObject private var watchService = WatchProximityService.shared
+    @State private var settings = Defaults.shared.appSettings
+    @State private var sensitivity: Double = 50
 
     var body: some View {
         Form {
             Section {
-                Toggle("Use Apple Watch to unlock", isOn: $useWatchUnlock)
-
-                if useWatchUnlock {
-                    HStack {
-                        Image(systemName: "applewatch.radiowaves.left.and.right")
-                            .font(.system(size: 24))
-                            .foregroundColor(MakLockColors.info)
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Searching for Apple Watch...")
-                                .font(MakLockTypography.body)
-                            Text("Make sure Bluetooth is on and your Watch is nearby.")
-                                .font(MakLockTypography.caption)
-                                .foregroundColor(.secondary)
+                Toggle("Use Apple Watch to unlock", isOn: $settings.useWatchUnlock)
+                    .onChange(of: settings.useWatchUnlock) { enabled in
+                        Defaults.shared.appSettings = settings
+                        if enabled {
+                            watchService.startScanning()
+                        } else {
+                            watchService.stopScanning()
                         }
                     }
-                    .padding(.vertical, 4)
+            }
+
+            if settings.useWatchUnlock {
+                Section("Paired Watch") {
+                    if let watchID = watchService.pairedWatchIdentifier {
+                        HStack {
+                            Image(systemName: "applewatch")
+                                .font(.system(size: 24))
+                                .foregroundColor(watchService.isWatchInRange ? MakLockColors.success : MakLockColors.textSecondary)
+
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Apple Watch")
+                                    .font(MakLockTypography.body)
+                                Text(watchService.isWatchInRange ? "In range" : "Out of range")
+                                    .font(MakLockTypography.caption)
+                                    .foregroundColor(watchService.isWatchInRange ? MakLockColors.success : .secondary)
+                            }
+
+                            Spacer()
+
+                            Button("Unpair") {
+                                watchService.unpair()
+                                settings.useWatchUnlock = false
+                                Defaults.shared.appSettings = settings
+                            }
+                            .foregroundColor(MakLockColors.error)
+                        }
+                        .padding(.vertical, 4)
+
+                        Text(watchID.uuidString)
+                            .font(.system(size: 10, design: .monospaced))
+                            .foregroundColor(.secondary)
+                            .textSelection(.enabled)
+                    } else {
+                        HStack {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Searching for Apple Watch...")
+                                .font(MakLockTypography.body)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.vertical, 4)
+
+                        Text("Make sure Bluetooth is on and your Watch is nearby.")
+                            .font(MakLockTypography.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                Section("Sensitivity") {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("Range:")
+                            Slider(value: $sensitivity, in: 0...100, step: 10)
+                                .onChange(of: sensitivity) { value in
+                                    // Map 0-100 slider to RSSI threshold: -90 (far) to -50 (close)
+                                    let rssi = Int(-90 + (value / 100.0) * 40)
+                                    watchService.rssiThreshold = rssi
+                                }
+                            Text(sensitivityLabel)
+                                .frame(width: 50, alignment: .trailing)
+                                .font(MakLockTypography.caption)
+                                .monospacedDigit()
+                        }
+
+                        Text("Lower sensitivity means the Watch can be farther away. Higher sensitivity requires the Watch to be closer.")
+                            .font(MakLockTypography.caption)
+                            .foregroundColor(.secondary)
+                    }
                 }
             }
 
             Section("How it works") {
-                Text("When your Apple Watch is nearby, MakLock can automatically unlock protected apps without requiring Touch ID or a password.")
+                Text("When your Apple Watch is nearby, MakLock can automatically unlock protected apps without requiring Touch ID or a password. If the Watch moves out of range, apps will be locked again.")
                     .font(MakLockTypography.caption)
                     .foregroundColor(.secondary)
             }
         }
         .formStyle(.grouped)
         .padding()
+        .onAppear {
+            // Map persisted RSSI threshold back to slider value
+            let rssi = Double(watchService.rssiThreshold)
+            sensitivity = ((rssi + 90) / 40.0) * 100
+        }
+    }
+
+    private var sensitivityLabel: String {
+        switch sensitivity {
+        case 0..<30: return "Far"
+        case 30..<70: return "Medium"
+        default: return "Close"
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add WatchProximityService using CoreBluetooth BLE scanning for Apple Watch detection
- Add Watch pairing UI with sensitivity slider in WatchSettingsView
- Wire Watch proximity into lock overlay: auto-unlock in range, auto-lock out of range

## Changes
- `WatchProximityService.swift` — CBCentralManager/CBPeripheralDelegate, RSSI threshold, auto-reconnect
- `WatchSettingsView.swift` — pairing status, unpair button, sensitivity slider (RSSI mapping)
- `AppDelegate.swift` — wires onWatchInRange/onWatchOutOfRange to overlay show/hide