### PR TITLE
Auto Touch ID and onboarding password setup

### DIFF
--- a/MakLock/App/AppDelegate.swift
+++ b/MakLock/App/AppDelegate.swift
@@ -25,30 +25,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.menuBarController.iconState = .locked
         }
 
-        // Wire up unlock: trigger Touch ID authentication
-        OverlayWindowService.shared.onUnlockRequested = { [weak self] app in
-            AuthenticationService.shared.authenticateWithTouchID(
-                reason: "Unlock \(app.name)"
-            ) { result in
-                switch result {
-                case .success:
-                    OverlayWindowService.shared.hide()
-                    self?.menuBarController.iconState = .active
-                case .failure:
-                    // Touch ID failed — user can try password fallback
-                    break
-                case .cancelled:
-                    break
-                }
-            }
-        }
-
-        // Wire up password fallback
-        OverlayWindowService.shared.onPasswordRequested = { [weak self] _ in
-            // Password input is handled in PasswordInputView
-            // On success, dismiss overlay
-            // This will be enhanced when PasswordInputView is integrated into overlay
-            _ = self
+        // Update icon when overlay is dismissed after successful auth
+        OverlayWindowService.shared.onUnlocked = { [weak self] in
+            self?.menuBarController.iconState = .active
         }
 
         // Start app monitoring

--- a/MakLock/Core/Services/OverlayWindowService.swift
+++ b/MakLock/Core/Services/OverlayWindowService.swift
@@ -9,11 +9,8 @@ final class OverlayWindowService {
     private var timeoutTimer: Timer?
     private var currentApp: ProtectedApp?
 
-    /// Callback when the user requests unlock (Touch ID or password).
-    var onUnlockRequested: ((ProtectedApp) -> Void)?
-
-    /// Callback when the user requests password input.
-    var onPasswordRequested: ((ProtectedApp) -> Void)?
+    /// Callback when overlay is dismissed after successful authentication.
+    var onUnlocked: (() -> Void)?
 
     private init() {
         // Observe screen configuration changes (connect/disconnect monitors)
@@ -74,11 +71,9 @@ final class OverlayWindowService {
             let overlayView = LockOverlayView(
                 appName: app.name,
                 bundleIdentifier: app.bundleIdentifier,
-                onUnlock: { [weak self] in
-                    self?.handleUnlock()
-                },
                 onDismiss: { [weak self] in
                     self?.hide()
+                    self?.onUnlocked?()
                 }
             )
 
@@ -106,10 +101,4 @@ final class OverlayWindowService {
         timeoutTimer = nil
     }
 
-    // MARK: - Private
-
-    private func handleUnlock() {
-        guard let app = currentApp else { return }
-        onUnlockRequested?(app)
-    }
 }

--- a/MakLock/UI/Onboarding/OnboardingView.swift
+++ b/MakLock/UI/Onboarding/OnboardingView.swift
@@ -1,57 +1,46 @@
 import SwiftUI
 
-/// First-launch onboarding view with welcome, safety tutorial, and setup steps.
+/// First-launch onboarding view with welcome, safety tutorial, password setup, and finish.
 struct OnboardingView: View {
     @State private var currentStep = 0
     let onComplete: () -> Void
 
-    private let steps = [
-        OnboardingStep(
+    /// Total number of steps (including interactive password step at index 2).
+    private let totalSteps = 5
+
+    private let infoSteps: [Int: OnboardingInfoStep] = [
+        0: OnboardingInfoStep(
             icon: "lock.shield.fill",
             title: "Welcome to MakLock",
             description: "Lock any macOS app with Touch ID or password. Your apps, your privacy."
         ),
-        OnboardingStep(
+        1: OnboardingInfoStep(
             icon: "exclamationmark.triangle.fill",
             title: "Panic Key",
             description: "If you ever get locked out, press\n⌘ ⌥ ⇧ ⌃ U\nto instantly dismiss all overlays.\n\nTry it now — it always works."
         ),
-        OnboardingStep(
+        // Step 2 is interactive (password setup)
+        3: OnboardingInfoStep(
             icon: "plus.app.fill",
             title: "Add Apps to Protect",
             description: "Open Settings → Apps to choose which applications require authentication. Start with a test app like Chess."
         ),
-        OnboardingStep(
+        4: OnboardingInfoStep(
             icon: "touchid",
             title: "You're All Set",
-            description: "MakLock runs in your menu bar. Protected apps will require Touch ID or your password to open."
+            description: "MakLock runs in your menu bar. Protected apps will require Touch ID to open — just put your finger on the sensor."
         )
     ]
 
     var body: some View {
         VStack(spacing: 0) {
             // Step content
-            VStack(spacing: 20) {
-                Spacer()
-
-                Image(systemName: steps[currentStep].icon)
-                    .font(.system(size: 48))
-                    .foregroundColor(MakLockColors.gold)
-                    .frame(height: 60)
-
-                Text(steps[currentStep].title)
-                    .font(MakLockTypography.largeTitle)
-                    .foregroundColor(MakLockColors.textPrimary)
-                    .multilineTextAlignment(.center)
-
-                Text(steps[currentStep].description)
-                    .font(MakLockTypography.body)
-                    .foregroundColor(MakLockColors.textSecondary)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: 320)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                Spacer()
+            Group {
+                if currentStep == 2 {
+                    PasswordSetupStep(onContinue: { advanceStep() })
+                } else if let info = infoSteps[currentStep] {
+                    InfoStepView(step: info)
+                }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .animation(MakLockAnimations.standard, value: currentStep)
@@ -60,7 +49,7 @@ struct OnboardingView: View {
             HStack {
                 // Step indicators
                 HStack(spacing: 8) {
-                    ForEach(0..<steps.count, id: \.self) { index in
+                    ForEach(0..<totalSteps, id: \.self) { index in
                         Circle()
                             .fill(index == currentStep ? MakLockColors.gold : Color.gray.opacity(0.3))
                             .frame(width: 8, height: 8)
@@ -69,27 +58,167 @@ struct OnboardingView: View {
 
                 Spacer()
 
-                if currentStep < steps.count - 1 {
-                    PrimaryButton("Continue") {
-                        withAnimation(MakLockAnimations.standard) {
-                            currentStep += 1
+                if currentStep != 2 {
+                    if currentStep < totalSteps - 1 {
+                        PrimaryButton("Continue") {
+                            advanceStep()
                         }
-                    }
-                } else {
-                    PrimaryButton("Get Started") {
-                        onComplete()
+                    } else {
+                        PrimaryButton("Get Started") {
+                            onComplete()
+                        }
                     }
                 }
             }
             .padding(.horizontal, 32)
             .padding(.bottom, 24)
         }
-        .frame(width: 480, height: 360)
+        .frame(width: 480, height: 420)
         .background(MakLockColors.background)
+    }
+
+    private func advanceStep() {
+        withAnimation(MakLockAnimations.standard) {
+            currentStep += 1
+        }
     }
 }
 
-private struct OnboardingStep {
+// MARK: - Info Step View
+
+private struct InfoStepView: View {
+    let step: OnboardingInfoStep
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+
+            Image(systemName: step.icon)
+                .font(.system(size: 48))
+                .foregroundColor(MakLockColors.gold)
+                .frame(height: 60)
+
+            Text(step.title)
+                .font(MakLockTypography.largeTitle)
+                .foregroundColor(MakLockColors.textPrimary)
+                .multilineTextAlignment(.center)
+
+            Text(step.description)
+                .font(MakLockTypography.body)
+                .foregroundColor(MakLockColors.textSecondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 320)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer()
+        }
+    }
+}
+
+// MARK: - Password Setup Step
+
+private struct PasswordSetupStep: View {
+    let onContinue: () -> Void
+
+    @State private var password = ""
+    @State private var confirmPassword = ""
+    @State private var errorMessage: String?
+    @State private var isSaved = false
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+
+            Image(systemName: "key.fill")
+                .font(.system(size: 48))
+                .foregroundColor(MakLockColors.gold)
+                .frame(height: 60)
+
+            Text("Set Backup Password")
+                .font(MakLockTypography.largeTitle)
+                .foregroundColor(MakLockColors.textPrimary)
+
+            Text("This password is used when Touch ID is unavailable.\nYou can change it later in Settings.")
+                .font(MakLockTypography.body)
+                .foregroundColor(MakLockColors.textSecondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 320)
+
+            if isSaved {
+                HStack(spacing: 8) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(MakLockColors.success)
+                    Text("Password saved!")
+                        .font(MakLockTypography.body)
+                        .foregroundColor(MakLockColors.success)
+                }
+                .padding(.top, 8)
+
+                PrimaryButton("Continue") {
+                    onContinue()
+                }
+            } else {
+                VStack(spacing: 12) {
+                    SecureField("Password (4+ characters)", text: $password)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 260)
+
+                    SecureField("Confirm Password", text: $confirmPassword)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 260)
+                        .onSubmit { savePassword() }
+                }
+
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(MakLockTypography.caption)
+                        .foregroundColor(MakLockColors.error)
+                }
+
+                HStack(spacing: 12) {
+                    SecondaryButton("Skip for now") {
+                        onContinue()
+                    }
+
+                    PrimaryButton("Save Password") {
+                        savePassword()
+                    }
+                }
+            }
+
+            Spacer()
+        }
+    }
+
+    private func savePassword() {
+        guard !password.isEmpty else {
+            errorMessage = "Password cannot be empty."
+            return
+        }
+        guard password.count >= 4 else {
+            errorMessage = "Password must be at least 4 characters."
+            return
+        }
+        guard password == confirmPassword else {
+            errorMessage = "Passwords do not match."
+            return
+        }
+
+        let saved = KeychainManager.shared.savePassword(password)
+        if saved {
+            Defaults.shared.isBackupPasswordSet = true
+            withAnimation(MakLockAnimations.standard) {
+                isSaved = true
+            }
+        } else {
+            errorMessage = "Failed to save. Please try again."
+        }
+    }
+}
+
+// MARK: - Models
+
+private struct OnboardingInfoStep {
     let icon: String
     let title: String
     let description: String

--- a/MakLock/UI/Onboarding/OnboardingWindow.swift
+++ b/MakLock/UI/Onboarding/OnboardingWindow.swift
@@ -30,7 +30,7 @@ final class OnboardingWindowController {
         let hostingView = NSHostingView(rootView: onboardingView)
 
         let newWindow = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 480, height: 360),
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 420),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false


### PR DESCRIPTION
## Summary
- Touch ID now triggers automatically when overlay appears — zero clicks needed
- First-launch onboarding includes backup password setup step
- Overlay shows spinner during authentication, retry + password fallback on failure
- Simplified OverlayWindowService: removed unused unlock/password callbacks

## UX Flow (before → after)
**Before:** Overlay → user clicks "Unlock" → Touch ID prompt → finger → done
**After:** Overlay → Touch ID prompt appears instantly → finger → done

## Onboarding Flow
1. Welcome to MakLock
2. Panic Key tutorial
3. **Set Backup Password** (interactive: password + confirm + save to Keychain)
4. Add Apps to Protect
5. You're All Set