### PR TITLE
Fix Touch ID focus, toggle colors, app search, and overlay stability

### DIFF
--- a/MakLock.xcodeproj/project.pbxproj
+++ b/MakLock.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		A10000000000000000000101 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000111 /* Colors.swift */; };
 		A10000000000000000000102 /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000112 /* Typography.swift */; };
 		A10000000000000000000103 /* Animations.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000113 /* Animations.swift */; };
+		A10000000000000000000108 /* ToggleStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000118 /* ToggleStyles.swift */; };
 		A10000000000000000000104 /* BlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000114 /* BlurView.swift */; };
 		A10000000000000000000105 /* PrimaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000115 /* PrimaryButton.swift */; };
 		A10000000000000000000106 /* SecondaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000116 /* SecondaryButton.swift */; };
@@ -59,6 +60,7 @@
 		A10000000000000000000111 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		A10000000000000000000112 /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
 		A10000000000000000000113 /* Animations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animations.swift; sourceTree = "<group>"; };
+		A10000000000000000000118 /* ToggleStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleStyles.swift; sourceTree = "<group>"; };
 		A10000000000000000000114 /* BlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurView.swift; sourceTree = "<group>"; };
 		A10000000000000000000115 /* PrimaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryButton.swift; sourceTree = "<group>"; };
 		A10000000000000000000116 /* SecondaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryButton.swift; sourceTree = "<group>"; };
@@ -198,6 +200,7 @@
 				A10000000000000000000111 /* Colors.swift */,
 				A10000000000000000000112 /* Typography.swift */,
 				A10000000000000000000113 /* Animations.swift */,
+				A10000000000000000000118 /* ToggleStyles.swift */,
 			);
 			path = Design;
 			sourceTree = "<group>";
@@ -372,6 +375,7 @@
 				A10000000000000000000101 /* Colors.swift in Sources */,
 				A10000000000000000000102 /* Typography.swift in Sources */,
 				A10000000000000000000103 /* Animations.swift in Sources */,
+				A10000000000000000000108 /* ToggleStyles.swift in Sources */,
 				A10000000000000000000104 /* BlurView.swift in Sources */,
 				A10000000000000000000105 /* PrimaryButton.swift in Sources */,
 				A10000000000000000000106 /* SecondaryButton.swift in Sources */,

--- a/MakLock/App/AppDelegate.swift
+++ b/MakLock/App/AppDelegate.swift
@@ -36,6 +36,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Wire up idle monitor → lock all protected apps
         IdleMonitorService.shared.onIdleTimeoutReached = { [weak self] in
             guard let self else { return }
+            AppMonitorService.shared.clearAllAuthentications()
             let apps = ProtectedAppsManager.shared.apps.filter(\.isEnabled)
             for app in apps {
                 OverlayWindowService.shared.show(for: app)
@@ -53,6 +54,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Wire up sleep/wake → lock all protected apps on sleep
         SleepWakeService.shared.onSleep = { [weak self] in
             guard let self else { return }
+            AppMonitorService.shared.clearAllAuthentications()
             let apps = ProtectedAppsManager.shared.apps.filter(\.isEnabled)
             for app in apps {
                 OverlayWindowService.shared.show(for: app)

--- a/MakLock/Core/Services/AppMonitorService.swift
+++ b/MakLock/Core/Services/AppMonitorService.swift
@@ -40,6 +40,20 @@ final class AppMonitorService: ObservableObject {
             .store(in: &cancellables)
 
         NSLog("[MakLock] App monitor started")
+
+        // Check already-running protected apps (e.g. after MakLock restart)
+        // Delay briefly to let the UI finish loading
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+            self?.checkRunningApps()
+        }
+    }
+
+    /// Scan currently running apps and trigger lock for any protected ones.
+    private func checkRunningApps() {
+        let workspace = NSWorkspace.shared
+        for runningApp in workspace.runningApplications {
+            handleAppEvent(runningApp)
+        }
     }
 
     /// Stop monitoring.

--- a/MakLock/UI/AppPicker/AppPickerView.swift
+++ b/MakLock/UI/AppPicker/AppPickerView.swift
@@ -113,8 +113,9 @@ struct AppPickerView: View {
                       !SafetyManager.isBlacklisted(bundleID),
                       !alreadyProtected.contains(bundleID) else { continue }
 
-                let name = bundle.object(forInfoDictionaryKey: "CFBundleName") as? String
-                    ?? item.replacingOccurrences(of: ".app", with: "")
+                // Use localized display name (works with any system language)
+                let name = FileManager.default.displayName(atPath: path)
+                    .replacingOccurrences(of: ".app", with: "")
 
                 apps.append(AppInfo(
                     bundleIdentifier: bundleID,

--- a/MakLock/UI/Design/ToggleStyles.swift
+++ b/MakLock/UI/Design/ToggleStyles.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+/// Custom switch toggle style using MakLock Gold for consistent appearance.
+/// Ignores the macOS system accent color — always renders gold when ON, gray when OFF,
+/// with a clearly visible white knob.
+struct GoldSwitchStyle: ToggleStyle {
+    var small = false
+
+    private var trackWidth: CGFloat { small ? 32 : 38 }
+    private var trackHeight: CGFloat { small ? 18 : 22 }
+    private var knobSize: CGFloat { small ? 14 : 18 }
+    private var knobPadding: CGFloat { 2 }
+
+    func makeBody(configuration: Configuration) -> some View {
+        HStack {
+            configuration.label
+
+            Spacer()
+
+            ZStack(alignment: configuration.isOn ? .trailing : .leading) {
+                Capsule()
+                    .fill(configuration.isOn ? MakLockColors.gold : Color(nsColor: .separatorColor))
+                    .frame(width: trackWidth, height: trackHeight)
+
+                Circle()
+                    .fill(Color.white)
+                    .shadow(color: .black.opacity(0.15), radius: 1, y: 1)
+                    .frame(width: knobSize, height: knobSize)
+                    .padding(knobPadding)
+            }
+            .animation(.easeInOut(duration: 0.15), value: configuration.isOn)
+            .onTapGesture {
+                configuration.isOn.toggle()
+            }
+        }
+    }
+}
+
+extension ToggleStyle where Self == GoldSwitchStyle {
+    /// MakLock Gold switch style — standard size.
+    static var goldSwitch: GoldSwitchStyle { GoldSwitchStyle() }
+
+    /// MakLock Gold switch style — compact size for popovers and tight layouts.
+    static var goldSwitchSmall: GoldSwitchStyle { GoldSwitchStyle(small: true) }
+}

--- a/MakLock/UI/LockOverlay/LockOverlayView.swift
+++ b/MakLock/UI/LockOverlay/LockOverlayView.swift
@@ -71,6 +71,7 @@ struct LockOverlayView: View {
                         .padding(.top, 4)
 
                         SecondaryButton("Use Password Instead") {
+                            OverlayWindowService.shared.enableKeyboardInput()
                             withAnimation(MakLockAnimations.standard) {
                                 showPasswordInput = true
                             }

--- a/MakLock/UI/LockOverlay/LockOverlayView.swift
+++ b/MakLock/UI/LockOverlay/LockOverlayView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct LockOverlayView: View {
     let appName: String
     let bundleIdentifier: String
+    let isPrimary: Bool
     let onDismiss: () -> Void
 
     @State private var isVisible = false
@@ -103,9 +104,11 @@ struct LockOverlayView: View {
             withAnimation(MakLockAnimations.overlayAppear) {
                 isVisible = true
             }
-            // Auto-trigger Touch ID after overlay animation
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                attemptTouchID()
+            // Only the primary screen triggers Touch ID (prevents duplicate system prompts)
+            if isPrimary {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    attemptTouchID()
+                }
             }
         }
     }

--- a/MakLock/UI/LockOverlay/LockOverlayView.swift
+++ b/MakLock/UI/LockOverlay/LockOverlayView.swift
@@ -117,9 +117,15 @@ struct LockOverlayView: View {
         authState = .authenticating
         errorMessage = nil
 
+        // Lower overlay level and pass through mouse so system Touch ID dialog gets full focus
+        OverlayWindowService.shared.setTouchIDMode(true)
+
         AuthenticationService.shared.authenticateWithTouchID(
             reason: "Unlock \(appName)"
         ) { result in
+            // Restore overlay level and mouse capture
+            OverlayWindowService.shared.setTouchIDMode(false)
+
             switch result {
             case .success:
                 onDismiss()

--- a/MakLock/UI/LockOverlay/LockOverlayWindow.swift
+++ b/MakLock/UI/LockOverlay/LockOverlayWindow.swift
@@ -1,18 +1,18 @@
 import AppKit
 
-/// Full-screen overlay window that blocks interaction with a protected app.
-final class LockOverlayWindow: NSWindow {
+/// Full-screen overlay panel that blocks interaction with a protected app.
+/// Uses NSPanel with .nonactivatingPanel so MakLock does NOT become the active app
+/// when the overlay is shown — this lets the system Touch ID dialog keep focus.
+final class LockOverlayWindow: NSPanel {
     init(for screen: NSScreen) {
         super.init(
             contentRect: screen.frame,
-            styleMask: .borderless,
+            styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
 
-        // Use statusBar level — high enough to be above normal windows and Dock,
-        // but below system security dialogs (Touch ID) which need focus priority
-        self.level = .statusBar
+        self.level = .screenSaver
         self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
         self.isOpaque = false
         self.backgroundColor = .clear
@@ -20,6 +20,8 @@ final class LockOverlayWindow: NSWindow {
         self.hasShadow = false
         self.isReleasedWhenClosed = false
         self.animationBehavior = .none
+        self.hidesOnDeactivate = false
+        self.becomesKeyOnlyIfNeeded = true
     }
 
     /// Reposition the overlay to match the given screen frame.

--- a/MakLock/UI/LockOverlay/LockOverlayWindow.swift
+++ b/MakLock/UI/LockOverlay/LockOverlayWindow.swift
@@ -25,6 +25,10 @@ final class LockOverlayWindow: NSWindow {
         setFrame(screen.frame, display: true)
     }
 
-    override var canBecomeKey: Bool { true }
+    /// Whether the window should accept key status.
+    /// Disabled during Touch ID (system dialog needs focus), enabled for password input.
+    var allowKeyStatus = false
+
+    override var canBecomeKey: Bool { allowKeyStatus }
     override var canBecomeMain: Bool { false }
 }

--- a/MakLock/UI/LockOverlay/LockOverlayWindow.swift
+++ b/MakLock/UI/LockOverlay/LockOverlayWindow.swift
@@ -10,7 +10,9 @@ final class LockOverlayWindow: NSWindow {
             defer: false
         )
 
-        self.level = .screenSaver
+        // Use statusBar level — high enough to be above normal windows and Dock,
+        // but below system security dialogs (Touch ID) which need focus priority
+        self.level = .statusBar
         self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
         self.isOpaque = false
         self.backgroundColor = .clear

--- a/MakLock/UI/MenuBar/MenuBarController.swift
+++ b/MakLock/UI/MenuBar/MenuBarController.swift
@@ -22,7 +22,9 @@ final class MenuBarController {
 
     func setup() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        updateIcon()
+
+        // Set initial icon based on protection state
+        iconState = Defaults.shared.appSettings.isProtectionEnabled ? .active : .idle
 
         let popover = NSPopover()
         popover.contentSize = NSSize(width: 260, height: 280)

--- a/MakLock/UI/MenuBar/MenuBarView.swift
+++ b/MakLock/UI/MenuBar/MenuBarView.swift
@@ -36,8 +36,7 @@ struct MenuBarView: View {
                     .foregroundColor(.secondary)
                 Spacer()
                 Toggle("", isOn: $isProtectionEnabled)
-                    .toggleStyle(.switch)
-                    .controlSize(.small)
+                    .toggleStyle(.goldSwitchSmall)
                     .labelsHidden()
                     .onChange(of: isProtectionEnabled) { _ in
                         onToggleProtection()

--- a/MakLock/UI/MenuBar/MenuBarView.swift
+++ b/MakLock/UI/MenuBar/MenuBarView.swift
@@ -106,6 +106,8 @@ private struct MenuBarButton: View {
     let icon: String
     let action: () -> Void
 
+    @State private var isHovered = false
+
     var body: some View {
         Button(action: action) {
             HStack(spacing: 10) {
@@ -118,8 +120,16 @@ private struct MenuBarButton: View {
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(isHovered ? Color.primary.opacity(0.1) : Color.clear)
+            )
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .onHover { hovering in
+            isHovered = hovering
+        }
+        .padding(.horizontal, 4)
     }
 }

--- a/MakLock/UI/Onboarding/OnboardingView.swift
+++ b/MakLock/UI/Onboarding/OnboardingView.swift
@@ -330,7 +330,7 @@ private struct FinalStep: View {
 
             VStack(spacing: 12) {
                 Toggle("Launch MakLock at login", isOn: $launchAtLogin)
-                    .toggleStyle(.switch)
+                    .toggleStyle(.goldSwitch)
 
                 Text("You can also configure idle auto-lock\nand other options in Settings.")
                     .font(MakLockTypography.caption)

--- a/MakLock/UI/Onboarding/OnboardingView.swift
+++ b/MakLock/UI/Onboarding/OnboardingView.swift
@@ -180,11 +180,9 @@ private struct KeyCap: View {
                         .shadow(color: .black.opacity(0.4), radius: 1, y: 2)
                 )
 
-            if let label {
-                Text(label)
-                    .font(.system(size: 8))
-                    .foregroundColor(MakLockColors.textSecondary)
-            }
+            Text(label ?? " ")
+                .font(.system(size: 8))
+                .foregroundColor(label != nil ? MakLockColors.textSecondary : .clear)
         }
     }
 }
@@ -333,7 +331,6 @@ private struct FinalStep: View {
             VStack(spacing: 12) {
                 Toggle("Launch MakLock at login", isOn: $launchAtLogin)
                     .toggleStyle(.switch)
-                    .tint(MakLockColors.gold)
 
                 Text("You can also configure idle auto-lock\nand other options in Settings.")
                     .font(MakLockTypography.caption)

--- a/MakLock/UI/Onboarding/OnboardingView.swift
+++ b/MakLock/UI/Onboarding/OnboardingView.swift
@@ -1,45 +1,43 @@
 import SwiftUI
+import ServiceManagement
 
 /// First-launch onboarding view with welcome, safety tutorial, password setup, and finish.
 struct OnboardingView: View {
     @State private var currentStep = 0
     let onComplete: () -> Void
 
-    /// Total number of steps (including interactive password step at index 2).
     private let totalSteps = 5
 
     private let infoSteps: [Int: OnboardingInfoStep] = [
         0: OnboardingInfoStep(
             icon: "lock.shield.fill",
             title: "Welcome to MakLock",
-            description: "Lock any macOS app with Touch ID or password. Your apps, your privacy."
+            description: "Lock any macOS app with Touch ID or password.\nYour apps, your privacy."
         ),
-        1: OnboardingInfoStep(
-            icon: "exclamationmark.triangle.fill",
-            title: "Panic Key",
-            description: "If you ever get locked out, press\n⌘ ⌥ ⇧ ⌃ U\nto instantly dismiss all overlays.\n\nTry it now — it always works."
-        ),
-        // Step 2 is interactive (password setup)
+        // Step 1 = Panic Key (custom view with visual keycaps)
+        // Step 2 = Password Setup (custom view)
         3: OnboardingInfoStep(
             icon: "plus.app.fill",
             title: "Add Apps to Protect",
-            description: "Open Settings → Apps to choose which applications require authentication. Start with a test app like Chess."
-        ),
-        4: OnboardingInfoStep(
-            icon: "touchid",
-            title: "You're All Set",
-            description: "MakLock runs in your menu bar. Protected apps will require Touch ID to open — just put your finger on the sensor."
+            description: "Open Settings → Apps to choose which applications require authentication.\n\nStart with a test app like Chess."
         )
+        // Step 4 = Final Step (custom view with Launch at Login toggle)
     ]
 
     var body: some View {
         VStack(spacing: 0) {
-            // Step content
             Group {
-                if currentStep == 2 {
+                switch currentStep {
+                case 1:
+                    PanicKeyStep()
+                case 2:
                     PasswordSetupStep(onContinue: { advanceStep() })
-                } else if let info = infoSteps[currentStep] {
-                    InfoStepView(step: info)
+                case 4:
+                    FinalStep()
+                default:
+                    if let info = infoSteps[currentStep] {
+                        InfoStepView(step: info)
+                    }
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -47,7 +45,6 @@ struct OnboardingView: View {
 
             // Navigation
             HStack {
-                // Step indicators
                 HStack(spacing: 8) {
                     ForEach(0..<totalSteps, id: \.self) { index in
                         Circle()
@@ -58,6 +55,7 @@ struct OnboardingView: View {
 
                 Spacer()
 
+                // Password step handles its own button
                 if currentStep != 2 {
                     if currentStep < totalSteps - 1 {
                         PrimaryButton("Continue") {
@@ -73,7 +71,7 @@ struct OnboardingView: View {
             .padding(.horizontal, 32)
             .padding(.bottom, 24)
         }
-        .frame(width: 480, height: 420)
+        .frame(width: 480, height: 440)
         .background(MakLockColors.background)
     }
 
@@ -84,7 +82,7 @@ struct OnboardingView: View {
     }
 }
 
-// MARK: - Info Step View
+// MARK: - Info Step
 
 private struct InfoStepView: View {
     let step: OnboardingInfoStep
@@ -107,10 +105,86 @@ private struct InfoStepView: View {
                 .font(MakLockTypography.body)
                 .foregroundColor(MakLockColors.textSecondary)
                 .multilineTextAlignment(.center)
-                .frame(maxWidth: 320)
+                .frame(maxWidth: 340)
                 .fixedSize(horizontal: false, vertical: true)
 
             Spacer()
+        }
+    }
+}
+
+// MARK: - Panic Key Step
+
+private struct PanicKeyStep: View {
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 48))
+                .foregroundColor(MakLockColors.gold)
+                .frame(height: 60)
+
+            Text("Emergency Panic Key")
+                .font(MakLockTypography.largeTitle)
+                .foregroundColor(MakLockColors.textPrimary)
+
+            Text("If you ever get locked out, this shortcut\ninstantly dismisses all overlays:")
+                .font(MakLockTypography.body)
+                .foregroundColor(MakLockColors.textSecondary)
+                .multilineTextAlignment(.center)
+
+            // Visual keyboard shortcut
+            HStack(spacing: 6) {
+                KeyCap("⌘", label: "Command")
+                Text("+").foregroundColor(MakLockColors.textSecondary)
+                KeyCap("⌥", label: "Option")
+                Text("+").foregroundColor(MakLockColors.textSecondary)
+                KeyCap("⇧", label: "Shift")
+                Text("+").foregroundColor(MakLockColors.textSecondary)
+                KeyCap("⌃", label: "Control")
+                Text("+").foregroundColor(MakLockColors.textSecondary)
+                KeyCap("U", label: nil)
+            }
+            .padding(.vertical, 8)
+
+            Text("Try it now — it always works, even in full screen.")
+                .font(MakLockTypography.caption)
+                .foregroundColor(MakLockColors.textSecondary)
+                .multilineTextAlignment(.center)
+
+            Spacer()
+        }
+    }
+}
+
+/// A visual keyboard key cap.
+private struct KeyCap: View {
+    let symbol: String
+    let label: String?
+
+    init(_ symbol: String, label: String?) {
+        self.symbol = symbol
+        self.label = label
+    }
+
+    var body: some View {
+        VStack(spacing: 2) {
+            Text(symbol)
+                .font(.system(size: 16, weight: .semibold, design: .rounded))
+                .foregroundColor(MakLockColors.textPrimary)
+                .frame(width: 36, height: 36)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(MakLockColors.cardDark)
+                        .shadow(color: .black.opacity(0.4), radius: 1, y: 2)
+                )
+
+            if let label {
+                Text(label)
+                    .font(.system(size: 8))
+                    .foregroundColor(MakLockColors.textSecondary)
+            }
         }
     }
 }
@@ -124,9 +198,10 @@ private struct PasswordSetupStep: View {
     @State private var confirmPassword = ""
     @State private var errorMessage: String?
     @State private var isSaved = false
+    @State private var showPassword = false
 
     var body: some View {
-        VStack(spacing: 20) {
+        VStack(spacing: 16) {
             Spacer()
 
             Image(systemName: "key.fill")
@@ -138,11 +213,11 @@ private struct PasswordSetupStep: View {
                 .font(MakLockTypography.largeTitle)
                 .foregroundColor(MakLockColors.textPrimary)
 
-            Text("This password is used when Touch ID is unavailable.\nYou can change it later in Settings.")
+            Text("Required as fallback when Touch ID is unavailable.\nYou can change it later in Settings.")
                 .font(MakLockTypography.body)
                 .foregroundColor(MakLockColors.textSecondary)
                 .multilineTextAlignment(.center)
-                .frame(maxWidth: 320)
+                .frame(maxWidth: 340)
 
             if isSaved {
                 HStack(spacing: 8) {
@@ -158,16 +233,23 @@ private struct PasswordSetupStep: View {
                     onContinue()
                 }
             } else {
-                VStack(spacing: 12) {
-                    SecureField("Password (4+ characters)", text: $password)
-                        .textFieldStyle(.roundedBorder)
-                        .frame(width: 260)
-
-                    SecureField("Confirm Password", text: $confirmPassword)
-                        .textFieldStyle(.roundedBorder)
-                        .frame(width: 260)
+                VStack(spacing: 10) {
+                    passwordField("Password (4+ characters)", text: $password)
+                    passwordField("Confirm Password", text: $confirmPassword)
                         .onSubmit { savePassword() }
                 }
+
+                // Show/hide toggle
+                Button(action: { showPassword.toggle() }) {
+                    HStack(spacing: 4) {
+                        Image(systemName: showPassword ? "eye.slash" : "eye")
+                            .font(.system(size: 11))
+                        Text(showPassword ? "Hide password" : "Show password")
+                            .font(MakLockTypography.caption)
+                    }
+                    .foregroundColor(MakLockColors.textSecondary)
+                }
+                .buttonStyle(.plain)
 
                 if let errorMessage {
                     Text(errorMessage)
@@ -175,19 +257,26 @@ private struct PasswordSetupStep: View {
                         .foregroundColor(MakLockColors.error)
                 }
 
-                HStack(spacing: 12) {
-                    SecondaryButton("Skip for now") {
-                        onContinue()
-                    }
-
-                    PrimaryButton("Save Password") {
-                        savePassword()
-                    }
+                PrimaryButton("Save Password") {
+                    savePassword()
                 }
             }
 
             Spacer()
         }
+    }
+
+    @ViewBuilder
+    private func passwordField(_ placeholder: String, text: Binding<String>) -> some View {
+        Group {
+            if showPassword {
+                TextField(placeholder, text: text)
+            } else {
+                SecureField(placeholder, text: text)
+            }
+        }
+        .textFieldStyle(.roundedBorder)
+        .frame(width: 260)
     }
 
     private func savePassword() {
@@ -212,6 +301,68 @@ private struct PasswordSetupStep: View {
             }
         } else {
             errorMessage = "Failed to save. Please try again."
+        }
+    }
+}
+
+// MARK: - Final Step
+
+private struct FinalStep: View {
+    @State private var launchAtLogin = true
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+
+            Image(systemName: "touchid")
+                .font(.system(size: 48))
+                .foregroundColor(MakLockColors.gold)
+                .frame(height: 60)
+
+            Text("You're All Set")
+                .font(MakLockTypography.largeTitle)
+                .foregroundColor(MakLockColors.textPrimary)
+                .multilineTextAlignment(.center)
+
+            Text("MakLock runs in your menu bar.\nProtected apps will require Touch ID — just put your finger on the sensor.")
+                .font(MakLockTypography.body)
+                .foregroundColor(MakLockColors.textSecondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 340)
+
+            VStack(spacing: 12) {
+                Toggle("Launch MakLock at login", isOn: $launchAtLogin)
+                    .toggleStyle(.switch)
+                    .tint(MakLockColors.gold)
+
+                Text("You can also configure idle auto-lock\nand other options in Settings.")
+                    .font(MakLockTypography.caption)
+                    .foregroundColor(MakLockColors.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.horizontal, 40)
+            .padding(.top, 8)
+
+            Spacer()
+        }
+        .onDisappear {
+            saveLaunchAtLogin()
+        }
+    }
+
+    private func saveLaunchAtLogin() {
+        var settings = Defaults.shared.appSettings
+        settings.launchAtLogin = launchAtLogin
+        Defaults.shared.appSettings = settings
+
+        do {
+            if launchAtLogin {
+                try SMAppService.mainApp.register()
+            } else {
+                try SMAppService.mainApp.unregister()
+            }
+        } catch {
+            NSLog("[MakLock] Failed to set login item: %@", error.localizedDescription)
         }
     }
 }

--- a/MakLock/UI/Onboarding/OnboardingWindow.swift
+++ b/MakLock/UI/Onboarding/OnboardingWindow.swift
@@ -31,15 +31,20 @@ final class OnboardingWindowController {
 
         let newWindow = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 480, height: 420),
-            styleMask: [.titled, .closable],
+            styleMask: [.titled],
             backing: .buffered,
             defer: false
         )
         newWindow.title = "Welcome to MakLock"
         newWindow.contentView = hostingView
         newWindow.isReleasedWhenClosed = false
+        newWindow.level = .floating
         newWindow.center()
         newWindow.makeKeyAndOrderFront(nil)
+        newWindow.orderFrontRegardless()
+
+        // Menu bar apps (LSUIElement) run in background — must activate explicitly
+        NSApp.activate(ignoringOtherApps: true)
 
         window = newWindow
     }

--- a/MakLock/UI/Settings/AppsSettingsView.swift
+++ b/MakLock/UI/Settings/AppsSettingsView.swift
@@ -63,6 +63,14 @@ struct AppsSettingsView: View {
                         set: { _ in manager.toggleApp(app) }
                     ))
                     .toggleStyle(.switch)
+                    .tint(MakLockColors.gold)
+
+                    Button(action: { manager.removeApp(app) }) {
+                        Image(systemName: "trash")
+                            .font(.system(size: 12))
+                            .foregroundColor(MakLockColors.error)
+                    }
+                    .buttonStyle(.plain)
                 }
                 .padding(.vertical, 4)
             }

--- a/MakLock/UI/Settings/AppsSettingsView.swift
+++ b/MakLock/UI/Settings/AppsSettingsView.swift
@@ -63,7 +63,6 @@ struct AppsSettingsView: View {
                         set: { _ in manager.toggleApp(app) }
                     ))
                     .toggleStyle(.switch)
-                    .tint(MakLockColors.gold)
 
                     Button(action: { manager.removeApp(app) }) {
                         Image(systemName: "trash")

--- a/MakLock/UI/Settings/AppsSettingsView.swift
+++ b/MakLock/UI/Settings/AppsSettingsView.swift
@@ -62,7 +62,7 @@ struct AppsSettingsView: View {
                         get: { app.isEnabled },
                         set: { _ in manager.toggleApp(app) }
                     ))
-                    .toggleStyle(.switch)
+                    .toggleStyle(.goldSwitch)
                     .labelsHidden()
 
                     Button(action: { manager.removeApp(app) }) {

--- a/MakLock/UI/Settings/AppsSettingsView.swift
+++ b/MakLock/UI/Settings/AppsSettingsView.swift
@@ -63,6 +63,7 @@ struct AppsSettingsView: View {
                         set: { _ in manager.toggleApp(app) }
                     ))
                     .toggleStyle(.switch)
+                    .labelsHidden()
 
                     Button(action: { manager.removeApp(app) }) {
                         Image(systemName: "trash")
@@ -71,6 +72,7 @@ struct AppsSettingsView: View {
                     }
                     .buttonStyle(.plain)
                 }
+                .id(app.id)
                 .padding(.vertical, 4)
             }
             .onDelete { indexSet in

--- a/MakLock/UI/Settings/GeneralSettingsView.swift
+++ b/MakLock/UI/Settings/GeneralSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import ServiceManagement
 
 /// General settings tab: launch at login, idle auto-lock, sleep auto-lock.
 struct GeneralSettingsView: View {
@@ -49,6 +50,21 @@ struct GeneralSettingsView: View {
             IdleMonitorService.shared.startMonitoring()
         } else {
             IdleMonitorService.shared.stopMonitoring()
+        }
+
+        // Register or unregister launch at login
+        updateLaunchAtLogin(enabled: settings.launchAtLogin)
+    }
+
+    private func updateLaunchAtLogin(enabled: Bool) {
+        do {
+            if enabled {
+                try SMAppService.mainApp.register()
+            } else {
+                try SMAppService.mainApp.unregister()
+            }
+        } catch {
+            NSLog("[MakLock] Failed to update login item: %@", error.localizedDescription)
         }
     }
 }

--- a/MakLock/UI/Settings/GeneralSettingsView.swift
+++ b/MakLock/UI/Settings/GeneralSettingsView.swift
@@ -9,12 +9,15 @@ struct GeneralSettingsView: View {
         Form {
             Section {
                 Toggle("Launch MakLock at login", isOn: $settings.launchAtLogin)
+                    .toggleStyle(.goldSwitch)
 
                 Toggle("Lock apps when Mac sleeps", isOn: $settings.lockOnSleep)
+                    .toggleStyle(.goldSwitch)
             }
 
             Section {
                 Toggle("Lock apps after idle timeout", isOn: $settings.lockOnIdle)
+                    .toggleStyle(.goldSwitch)
 
                 if settings.lockOnIdle {
                     HStack {

--- a/MakLock/UI/Settings/SecuritySettingsView.swift
+++ b/MakLock/UI/Settings/SecuritySettingsView.swift
@@ -13,11 +13,13 @@ struct SecuritySettingsView: View {
         Form {
             Section {
                 Toggle("Require authentication on app launch", isOn: $settings.requireAuthOnLaunch)
+                    .toggleStyle(.goldSwitch)
                     .onChange(of: settings.requireAuthOnLaunch) { _ in
                         Defaults.shared.appSettings = settings
                     }
 
                 Toggle("Require authentication on app switch", isOn: $settings.requireAuthOnActivate)
+                    .toggleStyle(.goldSwitch)
                     .onChange(of: settings.requireAuthOnActivate) { _ in
                         Defaults.shared.appSettings = settings
                     }


### PR DESCRIPTION
## Summary
- Fix Touch ID system dialog losing focus by changing overlay from NSWindow to NSPanel with `.nonactivatingPanel` — MakLock no longer becomes the active app, so the Touch ID dialog keeps focus permanently
- Add custom `GoldSwitchStyle` for consistent gold toggle appearance regardless of macOS system accent color
- Add Spotlight metadata search for localized app names (both "Szachy" and "Chess" find Chess.app)
- Fix double Touch ID prompt with `isAuthenticating` guard and `pendingLockBundleIDs` tracking
- Restore menu bar button hover effect
- Fix session-based auth, re-auth on app relaunch, startup app detection

## Changes
- `LockOverlayWindow` → `NSPanel` with `.nonactivatingPanel`, `.screenSaver` level
- Removed `app.hide()` on protected apps (overlay blur covers content, hiding caused focus conflicts)
- `AuthenticationService` — concurrent auth guard, LAContext cancellation
- `AppMonitorService` — pending lock tracking, termination listener, startup scan
- New `ToggleStyles.swift` with `GoldSwitchStyle`
- `AppPickerView` — Spotlight `MDItemCopyAttribute` for localized names
- `MenuBarView` — hover highlight on buttons

## Test plan
- [x] Touch ID dialog keeps focus (single and multi-monitor)
- [x] Touch ID sensor reads fingerprint without manual click
- [x] App unlocks and comes to foreground after auth
- [x] Re-auth required after app quit and relaunch
- [x] Toggle colors consistent (gold) across all views
- [x] "Chess" and "Szachy" both find Chess.app in picker
- [x] Menu bar hover effect works
- [x] Panic key still works
- [x] Onboarding flow complete