### PR TITLE
Fix app picker opening on wrong screen

### DIFF
--- a/MakLock/UI/AppPicker/AppPickerWindow.swift
+++ b/MakLock/UI/AppPicker/AppPickerWindow.swift
@@ -37,14 +37,21 @@ final class AppPickerWindowController {
         )
         window.title = "Add Applications"
         window.contentViewController = hostingController
-        window.center()
         window.isReleasedWhenClosed = false
+
+        // Position on the same screen as the parent window
+        if let parentWindow {
+            let parentFrame = parentWindow.frame
+            let pickerSize = window.frame.size
+            let x = parentFrame.midX - pickerSize.width / 2
+            let y = parentFrame.midY - pickerSize.height / 2
+            window.setFrameOrigin(NSPoint(x: x, y: y))
+        } else {
+            window.center()
+        }
+
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
-
-        if let parentWindow {
-            parentWindow.beginSheet(window)
-        }
 
         self.window = window
     }

--- a/MakLock/UI/Settings/AppsSettingsView.swift
+++ b/MakLock/UI/Settings/AppsSettingsView.swift
@@ -21,7 +21,7 @@ struct AppsSettingsView: View {
             HStack {
                 Spacer()
                 PrimaryButton("Add App", icon: "plus") {
-                    appPickerController.show()
+                    appPickerController.show(from: NSApp.keyWindow)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- App picker now opens centered over the Settings window instead of on the main display
- Passes parent window reference from AppsSettingsView via NSApp.keyWindow

## Test plan
- [ ] Open Settings on secondary display, click Add App — picker appears on same screen
- [ ] Open Settings on primary display, click Add App — still works correctly