### PR TITLE
Fix Watch proximity and settings bugs

### DIFF
--- a/MakLock.xcodeproj/project.pbxproj
+++ b/MakLock.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		A10000000000000000000801 /* LockOverlayWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000811 /* LockOverlayWindow.swift */; };
 		A10000000000000000000802 /* LockOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000812 /* LockOverlayView.swift */; };
 		A10000000000000000000803 /* OverlayWindowService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000813 /* OverlayWindowService.swift */; };
+		A10000000000000000000804 /* WatchUnlockToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000814 /* WatchUnlockToast.swift */; };
 		A10000000000000000000901 /* AuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000911 /* AuthenticationService.swift */; };
 		A10000000000000000000902 /* PasswordInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000912 /* PasswordInputView.swift */; };
 		A10000000000000000000A01 /* IdleMonitorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000A11 /* IdleMonitorService.swift */; };
@@ -88,6 +89,7 @@
 		A10000000000000000000811 /* LockOverlayWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockOverlayWindow.swift; sourceTree = "<group>"; };
 		A10000000000000000000812 /* LockOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockOverlayView.swift; sourceTree = "<group>"; };
 		A10000000000000000000813 /* OverlayWindowService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayWindowService.swift; sourceTree = "<group>"; };
+		A10000000000000000000814 /* WatchUnlockToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchUnlockToast.swift; sourceTree = "<group>"; };
 		A10000000000000000000911 /* AuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationService.swift; sourceTree = "<group>"; };
 		A10000000000000000000912 /* PasswordInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordInputView.swift; sourceTree = "<group>"; };
 		A10000000000000000000A11 /* IdleMonitorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleMonitorService.swift; sourceTree = "<group>"; };
@@ -245,6 +247,7 @@
 				A10000000000000000000811 /* LockOverlayWindow.swift */,
 				A10000000000000000000812 /* LockOverlayView.swift */,
 				A10000000000000000000912 /* PasswordInputView.swift */,
+				A10000000000000000000814 /* WatchUnlockToast.swift */,
 			);
 			path = LockOverlay;
 			sourceTree = "<group>";
@@ -405,6 +408,7 @@
 				A10000000000000000000803 /* OverlayWindowService.swift in Sources */,
 				A10000000000000000000901 /* AuthenticationService.swift in Sources */,
 				A10000000000000000000902 /* PasswordInputView.swift in Sources */,
+				A10000000000000000000804 /* WatchUnlockToast.swift in Sources */,
 				A10000000000000000000A01 /* IdleMonitorService.swift in Sources */,
 				A10000000000000000000B01 /* SleepWakeService.swift in Sources */,
 				A10000000000000000000C01 /* WatchProximityService.swift in Sources */,

--- a/MakLock/Core/Managers/SafetyManager.swift
+++ b/MakLock/Core/Managers/SafetyManager.swift
@@ -28,7 +28,7 @@ final class SafetyManager {
     static let overlayTimeout: TimeInterval = 60
 
     /// Dev mode auto-dismiss time (seconds).
-    static let devModeTimeout: TimeInterval = 10
+    static let devModeTimeout: TimeInterval = 25
 
     /// Bundle identifiers that can never be locked.
     static let systemBlacklist: Set<String> = [

--- a/MakLock/Core/Storage/KeychainManager.swift
+++ b/MakLock/Core/Storage/KeychainManager.swift
@@ -37,8 +37,18 @@ final class KeychainManager {
     }
 
     /// Check whether a backup password exists in the Keychain.
+    /// Uses attribute-only query to avoid triggering the Keychain authorization dialog.
     func hasPassword() -> Bool {
-        return retrievePassword() != nil
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        return status == errSecSuccess
     }
 
     /// Remove the stored password from the Keychain.

--- a/MakLock/Models/AppSettings.swift
+++ b/MakLock/Models/AppSettings.swift
@@ -23,6 +23,10 @@ struct AppSettings: Codable {
     /// Use Apple Watch proximity for auto-unlock.
     var useWatchUnlock: Bool = false
 
+    /// Watch RSSI threshold for proximity detection.
+    /// Default: -70 dBm (~2-3 meters). Higher (less negative) = stricter.
+    var watchRssiThreshold: Int = -70
+
     /// Launch MakLock at login.
     var launchAtLogin: Bool = false
 }

--- a/MakLock/UI/LockOverlay/WatchUnlockToast.swift
+++ b/MakLock/UI/LockOverlay/WatchUnlockToast.swift
@@ -1,0 +1,136 @@
+import AppKit
+import SwiftUI
+
+/// Brief HUD toast shown when an app is auto-unlocked via Apple Watch proximity.
+/// Appears centered on the primary screen for 2 seconds, then fades out.
+final class WatchUnlockToast {
+    static let shared = WatchUnlockToast()
+
+    private var window: NSPanel?
+    private var dismissTimer: Timer?
+
+    private init() {}
+
+    /// Show the "Unlocked with Apple Watch" toast on the given app's screen.
+    func show(for bundleIdentifier: String? = nil) {
+        // Don't stack multiple toasts
+        dismiss()
+
+        let toast = NSPanel(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        toast.isOpaque = false
+        toast.backgroundColor = .clear
+        toast.hasShadow = false
+        toast.level = .floating
+        toast.hidesOnDeactivate = false
+        toast.collectionBehavior = [.canJoinAllSpaces, .transient]
+        toast.isMovableByWindowBackground = false
+        toast.ignoresMouseEvents = true
+
+        let view = NSHostingView(rootView: WatchUnlockToastView())
+        view.frame.size = view.fittingSize
+        toast.setContentSize(view.fittingSize)
+        toast.contentView = view
+
+        // Find the screen where the protected app lives
+        let screen = screenForApp(bundleIdentifier) ?? NSScreen.main ?? NSScreen.screens[0]
+        let screenFrame = screen.frame
+        let toastSize = toast.frame.size
+        let x = screenFrame.midX - toastSize.width / 2
+        let y = screenFrame.midY - toastSize.height / 2
+        toast.setFrameOrigin(NSPoint(x: x, y: y))
+
+        toast.alphaValue = 0
+        toast.orderFront(nil)
+
+        self.window = toast
+
+        // Fade in
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.25
+            toast.animator().alphaValue = 1
+        }
+
+        // Auto-dismiss after 4 seconds
+        dismissTimer = Timer.scheduledTimer(withTimeInterval: 4.0, repeats: false) { [weak self] _ in
+            self?.dismiss()
+        }
+    }
+
+    /// Find the screen containing the frontmost window of the given app.
+    private func screenForApp(_ bundleIdentifier: String?) -> NSScreen? {
+        guard let bundleIdentifier else { return nil }
+        guard let app = NSWorkspace.shared.runningApplications.first(where: { $0.bundleIdentifier == bundleIdentifier }) else { return nil }
+
+        // Get the app's windows via CGWindowList
+        let windowList = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] ?? []
+        for windowInfo in windowList {
+            guard let ownerPID = windowInfo[kCGWindowOwnerPID as String] as? pid_t,
+                  ownerPID == app.processIdentifier,
+                  let bounds = windowInfo[kCGWindowBounds as String] as? [String: CGFloat],
+                  let wx = bounds["X"], let wy = bounds["Y"],
+                  let ww = bounds["Width"], let wh = bounds["Height"],
+                  ww > 0, wh > 0 else { continue }
+
+            let windowCenter = NSPoint(x: wx + ww / 2, y: wy + wh / 2)
+            // Find which screen contains this window's center
+            for screen in NSScreen.screens {
+                // Convert screen frame to CGWindow coordinate space (origin top-left)
+                let sf = screen.frame
+                let mainHeight = NSScreen.screens[0].frame.height
+                let cgRect = CGRect(x: sf.origin.x, y: mainHeight - sf.origin.y - sf.height, width: sf.width, height: sf.height)
+                if cgRect.contains(windowCenter) {
+                    return screen
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Dismiss the toast with fade-out.
+    func dismiss() {
+        dismissTimer?.invalidate()
+        dismissTimer = nil
+
+        guard let window else { return }
+
+        NSAnimationContext.runAnimationGroup({ ctx in
+            ctx.duration = 0.3
+            window.animator().alphaValue = 0
+        }, completionHandler: { [weak self] in
+            self?.window?.close()
+            self?.window = nil
+        })
+    }
+}
+
+/// The SwiftUI content for the Watch unlock toast.
+private struct WatchUnlockToastView: View {
+    var body: some View {
+        HStack(spacing: 16) {
+            Image(systemName: "applewatch")
+                .font(.system(size: 32))
+                .foregroundColor(MakLockColors.gold)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Unlocked")
+                    .font(MakLockTypography.headline)
+                    .foregroundColor(MakLockColors.textPrimary)
+                Text("Apple Watch is nearby")
+                    .font(MakLockTypography.caption)
+                    .foregroundColor(MakLockColors.textSecondary)
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 18)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(MakLockColors.cardDark)
+                .shadow(color: .black.opacity(0.4), radius: 16, y: 6)
+        )
+    }
+}

--- a/MakLock/UI/MenuBar/MenuBarController.swift
+++ b/MakLock/UI/MenuBar/MenuBarController.swift
@@ -35,7 +35,8 @@ final class MenuBarController {
             },
             onSettingsClicked: { [weak self] in
                 self?.hidePopover()
-                NotificationCenter.default.post(name: .openSettings, object: nil)
+                let screen = self?.statusItem?.button?.window?.screen
+                NotificationCenter.default.post(name: .openSettings, object: screen)
             },
             onQuitClicked: {
                 NSApplication.shared.terminate(nil)

--- a/MakLock/UI/Settings/SettingsWindow.swift
+++ b/MakLock/UI/Settings/SettingsWindow.swift
@@ -16,8 +16,11 @@ final class SettingsWindowController {
         )
     }
 
-    @objc func openSettings() {
+    @objc func openSettings(_ notification: Notification) {
+        let targetScreen = notification.object as? NSScreen ?? NSScreen.main ?? NSScreen.screens[0]
+
         if let window {
+            centerWindow(window, on: targetScreen)
             window.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
             return
@@ -34,11 +37,21 @@ final class SettingsWindowController {
         )
         window.title = "MakLock Settings"
         window.contentViewController = hostingController
-        window.center()
         window.isReleasedWhenClosed = false
+        centerWindow(window, on: targetScreen)
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
 
         self.window = window
+    }
+
+    private func centerWindow(_ window: NSWindow, on screen: NSScreen) {
+        let screenFrame = screen.visibleFrame
+        let windowSize = window.frame.size
+        let origin = NSPoint(
+            x: screenFrame.midX - windowSize.width / 2,
+            y: screenFrame.midY - windowSize.height / 2
+        )
+        window.setFrameOrigin(origin)
     }
 }


### PR DESCRIPTION
## Summary
- Fix critical SwiftUI infinite layout loop in WatchSettingsView (`.textSelection(.enabled)` in Form inside TabView on macOS 26)
- Add "Unlocked with Apple Watch" toast HUD shown on auto-unlock
- Clear auth sessions when Watch goes out of range to prevent stale sessions
- Fix protected app not activating after Watch auto-unlock (use `NSWorkspace.openApplication`)
- Persist Watch RSSI sensitivity threshold across app restarts
- Fix settings window always opening on primary screen instead of status bar screen
- Fix Keychain authorization dialog appearing when clicking Security tab
- Improve BLE scanning with advertisement data name fallback and detailed logging
- Fix unnecessary SwiftUI re-renders from RSSI polling
- Add Watch auto-unlock when opening protected app while Watch is in range
- Increase dev mode overlay timeout from 10s to 25s

## Test plan
- [x] Watch tab no longer freezes when switching tabs in Settings
- [x] Walk away from Mac → overlay appears with Touch ID
- [x] Return to Mac → overlay dismisses, toast shows, app activates
- [x] Open protected app with Watch nearby → toast shows, no overlay
- [x] RSSI threshold persists after app restart
- [x] Settings window opens on correct screen
- [x] Security tab opens without Keychain dialog