### PR TITLE
Add Watch lock state detection and unlock notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ Package.resolved
 
 # Local development config
 CLAUDE.md
-CURRENT_TASK.md
 .claude/
 .mcp.json
 


### PR DESCRIPTION
## Summary
- Detect Apple Watch on-wrist/off-wrist state via BLE Continuity Nearby Info packets
- Watch off wrist no longer auto-unlocks apps (falls through to Touch ID)
- Add macOS notifications for both Watch and Touch ID unlock events
- Lock/unlock callbacks only affect running apps (never launch closed apps)
- Watch BLE scanning starts before app monitoring to prevent false triggers on restart

## Technical Details
- Parse Apple Continuity "Nearby Info" advertisement data (manufacturer data type 0x10, bit 7 of data flags = lock state)
- Debounce: 5 consecutive "locked" readings before state change (prevents BLE flapping)
- RSSI used only for proximity; lock state checked separately at unlock time
- `activateProtectedApp` now uses `NSRunningApplication.activate()` instead of `NSWorkspace.openApplication`

## Test plan
- [ ] Open Chess with Watch on wrist → Watch auto-unlock + toast + notification
- [ ] Take off Watch, wait 20s → Chess stays open (no re-lock)
- [ ] Close Chess, reopen → Touch ID (Watch off wrist)
- [ ] Put Watch back on, reopen Chess → Watch auto-unlock again
- [ ] Walk away → running apps lock; come back → auto-unlock
- [ ] Verify closed apps never launch on their own