### PR TITLE
Add auto-close for inactive protected apps

### DIFF
--- a/MakLock.xcodeproj/project.pbxproj
+++ b/MakLock.xcodeproj/project.pbxproj
@@ -7,17 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C36B23C6F719E84D10ECE91 /* AppInactivityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D8AAF1355AD0ACA8137F01D /* AppInactivityService.swift */; };
 		A10000000000000000000001 /* MakLockApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000011 /* MakLockApp.swift */; };
 		A10000000000000000000002 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000012 /* Assets.xcassets */; };
-		A10000000000000000000F03 /* HotKey in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000F02 /* HotKey */; };
 		A10000000000000000000101 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000111 /* Colors.swift */; };
 		A10000000000000000000102 /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000112 /* Typography.swift */; };
 		A10000000000000000000103 /* Animations.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000113 /* Animations.swift */; };
-		A10000000000000000000108 /* ToggleStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000118 /* ToggleStyles.swift */; };
 		A10000000000000000000104 /* BlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000114 /* BlurView.swift */; };
 		A10000000000000000000105 /* PrimaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000115 /* PrimaryButton.swift */; };
 		A10000000000000000000106 /* SecondaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000116 /* SecondaryButton.swift */; };
 		A10000000000000000000107 /* AppIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000117 /* AppIconView.swift */; };
+		A10000000000000000000108 /* ToggleStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000118 /* ToggleStyles.swift */; };
 		A10000000000000000000201 /* ProtectedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000211 /* ProtectedApp.swift */; };
 		A10000000000000000000202 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000212 /* AppSettings.swift */; };
 		A10000000000000000000203 /* LockSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000213 /* LockSession.swift */; };
@@ -50,9 +50,11 @@
 		A10000000000000000000D01 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000D11 /* OnboardingView.swift */; };
 		A10000000000000000000D02 /* OnboardingWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000D12 /* OnboardingWindow.swift */; };
 		A10000000000000000000E01 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000E11 /* AboutView.swift */; };
+		A10000000000000000000F03 /* HotKey in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000F02 /* HotKey */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4D8AAF1355AD0ACA8137F01D /* AppInactivityService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppInactivityService.swift; sourceTree = "<group>"; };
 		A10000000000000000000010 /* MakLock.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MakLock.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000000000000000000011 /* MakLockApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakLockApp.swift; sourceTree = "<group>"; };
 		A10000000000000000000012 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -61,11 +63,11 @@
 		A10000000000000000000111 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		A10000000000000000000112 /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
 		A10000000000000000000113 /* Animations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animations.swift; sourceTree = "<group>"; };
-		A10000000000000000000118 /* ToggleStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleStyles.swift; sourceTree = "<group>"; };
 		A10000000000000000000114 /* BlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurView.swift; sourceTree = "<group>"; };
 		A10000000000000000000115 /* PrimaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryButton.swift; sourceTree = "<group>"; };
 		A10000000000000000000116 /* SecondaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryButton.swift; sourceTree = "<group>"; };
 		A10000000000000000000117 /* AppIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconView.swift; sourceTree = "<group>"; };
+		A10000000000000000000118 /* ToggleStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleStyles.swift; sourceTree = "<group>"; };
 		A10000000000000000000211 /* ProtectedApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectedApp.swift; sourceTree = "<group>"; };
 		A10000000000000000000212 /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
 		A10000000000000000000213 /* LockSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockSession.swift; sourceTree = "<group>"; };
@@ -141,6 +143,24 @@
 			path = App;
 			sourceTree = "<group>";
 		};
+		A10000000000000000000033 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000012 /* Assets.xcassets */,
+				A10000000000000000000013 /* Info.plist */,
+				A10000000000000000000014 /* MakLock.entitlements */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000034 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000010 /* MakLock.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		A100000000000000000000C0 /* Core */ = {
 			isa = PBXGroup;
 			children = (
@@ -160,6 +180,7 @@
 				A10000000000000000000A11 /* IdleMonitorService.swift */,
 				A10000000000000000000B11 /* SleepWakeService.swift */,
 				A10000000000000000000C11 /* WatchProximityService.swift */,
+				4D8AAF1355AD0ACA8137F01D /* AppInactivityService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -281,24 +302,6 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
-		A10000000000000000000033 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				A10000000000000000000012 /* Assets.xcassets */,
-				A10000000000000000000013 /* Info.plist */,
-				A10000000000000000000014 /* MakLock.entitlements */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		A10000000000000000000034 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				A10000000000000000000010 /* MakLock.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -346,12 +349,12 @@
 				Base,
 			);
 			mainGroup = A10000000000000000000030;
-			productRefGroup = A10000000000000000000034 /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
 			packageReferences = (
 				A10000000000000000000F01 /* XCRemoteSwiftPackageReference "HotKey" */,
 			);
+			productRefGroup = A10000000000000000000034 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
 			targets = (
 				A10000000000000000000040 /* MakLock */,
 			);
@@ -401,8 +404,8 @@
 				A10000000000000000000506 /* WatchSettingsView.swift in Sources */,
 				A10000000000000000000601 /* AppMonitorService.swift in Sources */,
 				A10000000000000000000602 /* ProtectedAppsManager.swift in Sources */,
-			A10000000000000000000701 /* AppPickerView.swift in Sources */,
-			A10000000000000000000702 /* AppPickerWindow.swift in Sources */,
+				A10000000000000000000701 /* AppPickerView.swift in Sources */,
+				A10000000000000000000702 /* AppPickerWindow.swift in Sources */,
 				A10000000000000000000801 /* LockOverlayWindow.swift in Sources */,
 				A10000000000000000000802 /* LockOverlayView.swift in Sources */,
 				A10000000000000000000803 /* OverlayWindowService.swift in Sources */,
@@ -415,6 +418,7 @@
 				A10000000000000000000D01 /* OnboardingView.swift in Sources */,
 				A10000000000000000000D02 /* OnboardingWindow.swift in Sources */,
 				A10000000000000000000E01 /* AboutView.swift in Sources */,
+				3C36B23C6F719E84D10ECE91 /* AppInactivityService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -546,6 +550,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MakLock/Resources/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright 2026 MakMak. All rights reserved.";
@@ -554,7 +559,6 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				ENABLE_HARDENED_RUNTIME = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.makmak.MakLock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -573,6 +577,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MakLock/Resources/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright 2026 MakMak. All rights reserved.";
@@ -581,7 +586,6 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				ENABLE_HARDENED_RUNTIME = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.makmak.MakLock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -634,7 +638,6 @@
 			productName = HotKey;
 		};
 /* End XCSwiftPackageProductDependency section */
-
 	};
 	rootObject = A10000000000000000000041 /* Project object */;
 }

--- a/MakLock/App/AppDelegate.swift
+++ b/MakLock/App/AppDelegate.swift
@@ -61,6 +61,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             AppMonitorService.shared.startMonitoring()
         }
 
+        // Start auto-close monitoring if any protected app has auto-close enabled
+        if ProtectedAppsManager.shared.apps.contains(where: { $0.autoClose }) {
+            AppInactivityService.shared.startMonitoring()
+        }
+
         // Wire up idle monitor → lock all running protected apps
         IdleMonitorService.shared.onIdleTimeoutReached = { [weak self] in
             guard let self else { return }

--- a/MakLock/Core/Managers/ProtectedAppsManager.swift
+++ b/MakLock/Core/Managers/ProtectedAppsManager.swift
@@ -48,6 +48,18 @@ final class ProtectedAppsManager: ObservableObject {
         save()
     }
 
+    /// Toggle auto-close on or off for an app.
+    func toggleAutoClose(_ app: ProtectedApp) {
+        guard let index = apps.firstIndex(where: { $0.id == app.id }) else { return }
+        apps[index].autoClose.toggle()
+        save()
+
+        // Cancel pending timer if auto-close was disabled
+        if !apps[index].autoClose {
+            AppInactivityService.shared.cancelTimer(for: app.bundleIdentifier)
+        }
+    }
+
     /// Check whether an app with the given bundle identifier is protected and enabled.
     func isProtected(_ bundleIdentifier: String) -> Bool {
         return apps.contains { $0.bundleIdentifier == bundleIdentifier && $0.isEnabled }

--- a/MakLock/Core/Services/AppInactivityService.swift
+++ b/MakLock/Core/Services/AppInactivityService.swift
@@ -1,0 +1,122 @@
+import AppKit
+
+/// Tracks per-app inactivity and terminates protected apps that have auto-close enabled
+/// after the configured timeout. Prevents notifications from locked messaging apps.
+final class AppInactivityService: ObservableObject {
+    static let shared = AppInactivityService()
+
+    @Published private(set) var isMonitoring = false
+
+    /// Per-app close timers: bundleID → Timer
+    private var closeTimers: [String: Timer] = [:]
+
+    /// Last active protected app bundle ID (to start timer when it loses focus).
+    private var lastActiveProtectedBundleID: String?
+
+    private var activateObserver: Any?
+
+    private init() {}
+
+    /// Start monitoring app activations for auto-close.
+    func startMonitoring() {
+        guard !isMonitoring else { return }
+
+        activateObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            self?.handleAppActivation(notification)
+        }
+
+        isMonitoring = true
+        NSLog("[MakLock] AppInactivityService started monitoring")
+    }
+
+    /// Stop monitoring and cancel all pending close timers.
+    func stopMonitoring() {
+        if let observer = activateObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+            activateObserver = nil
+        }
+
+        cancelAllTimers()
+        lastActiveProtectedBundleID = nil
+        isMonitoring = false
+        NSLog("[MakLock] AppInactivityService stopped monitoring")
+    }
+
+    /// Cancel the close timer for a specific app (e.g. when auto-close is toggled off).
+    func cancelTimer(for bundleID: String) {
+        closeTimers[bundleID]?.invalidate()
+        closeTimers.removeValue(forKey: bundleID)
+    }
+
+    // MARK: - Private
+
+    private func handleAppActivation(_ notification: Notification) {
+        guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
+              let bundleID = app.bundleIdentifier else { return }
+
+        // If the previously active app was a protected auto-close app, start its timer
+        if let previousBundleID = lastActiveProtectedBundleID, previousBundleID != bundleID {
+            startCloseTimer(for: previousBundleID)
+        }
+
+        // If the newly activated app is a protected auto-close app, cancel its timer
+        if shouldAutoClose(bundleID) {
+            cancelTimer(for: bundleID)
+            lastActiveProtectedBundleID = bundleID
+        } else {
+            lastActiveProtectedBundleID = nil
+        }
+    }
+
+    private func shouldAutoClose(_ bundleID: String) -> Bool {
+        guard !SafetyManager.isBlacklisted(bundleID) else { return false }
+        return ProtectedAppsManager.shared.apps.contains {
+            $0.bundleIdentifier == bundleID && $0.isEnabled && $0.autoClose
+        }
+    }
+
+    private func startCloseTimer(for bundleID: String) {
+        guard shouldAutoClose(bundleID) else { return }
+
+        // Cancel existing timer if any
+        cancelTimer(for: bundleID)
+
+        let timeout = TimeInterval(Defaults.shared.appSettings.inactiveCloseMinutes) * 60
+
+        closeTimers[bundleID] = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) { [weak self] _ in
+            self?.terminateApp(bundleID)
+        }
+
+        NSLog("[MakLock] Auto-close timer started for %@ (%.0f min)", bundleID, timeout / 60)
+    }
+
+    private func cancelAllTimers() {
+        closeTimers.values.forEach { $0.invalidate() }
+        closeTimers.removeAll()
+    }
+
+    private func terminateApp(_ bundleID: String) {
+        closeTimers.removeValue(forKey: bundleID)
+
+        guard !SafetyManager.isBlacklisted(bundleID) else {
+            NSLog("[MakLock] Refusing to auto-close blacklisted app: %@", bundleID)
+            return
+        }
+
+        guard let app = NSWorkspace.shared.runningApplications.first(where: { $0.bundleIdentifier == bundleID }) else {
+            NSLog("[MakLock] App already closed: %@", bundleID)
+            return
+        }
+
+        let name = app.localizedName ?? bundleID
+        app.terminate()
+        NSLog("[MakLock] Auto-closed inactive app: %@ (%@)", name, bundleID)
+
+        // Clear authentication so overlay appears on next launch
+        AppMonitorService.shared.clearAuthentication(for: bundleID)
+    }
+}

--- a/MakLock/Models/AppSettings.swift
+++ b/MakLock/Models/AppSettings.swift
@@ -27,6 +27,9 @@ struct AppSettings: Codable {
     /// Default: -70 dBm (~2-3 meters). Higher (less negative) = stricter.
     var watchRssiThreshold: Int = -70
 
+    /// Inactivity timeout (minutes) before auto-closing protected apps that have autoClose enabled.
+    var inactiveCloseMinutes: Int = 15
+
     /// Launch MakLock at login.
     var launchAtLogin: Bool = false
 }

--- a/MakLock/Models/ProtectedApp.swift
+++ b/MakLock/Models/ProtectedApp.swift
@@ -17,6 +17,11 @@ struct ProtectedApp: Codable, Identifiable, Hashable {
     /// Whether protection is currently enabled for this app.
     var isEnabled: Bool
 
+    /// Whether to auto-close this app after inactivity timeout.
+    /// When enabled, the app will be terminated after the global inactive timeout
+    /// to prevent notifications from appearing while the app is locked.
+    var autoClose: Bool
+
     /// Date the app was added to the protected list.
     let dateAdded: Date
 
@@ -26,6 +31,7 @@ struct ProtectedApp: Codable, Identifiable, Hashable {
         name: String,
         path: String,
         isEnabled: Bool = true,
+        autoClose: Bool = false,
         dateAdded: Date = Date()
     ) {
         self.id = id
@@ -33,6 +39,7 @@ struct ProtectedApp: Codable, Identifiable, Hashable {
         self.name = name
         self.path = path
         self.isEnabled = isEnabled
+        self.autoClose = autoClose
         self.dateAdded = dateAdded
     }
 }

--- a/MakLock/UI/Settings/AppsSettingsView.swift
+++ b/MakLock/UI/Settings/AppsSettingsView.swift
@@ -58,6 +58,16 @@ struct AppsSettingsView: View {
                             .foregroundColor(.secondary)
                     }
                     Spacer()
+
+                    // Auto-close toggle
+                    Button(action: { manager.toggleAutoClose(app) }) {
+                        Image(systemName: app.autoClose ? "timer" : "timer")
+                            .font(.system(size: 12))
+                            .foregroundColor(app.autoClose ? MakLockColors.gold : MakLockColors.textSecondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help(app.autoClose ? "Auto-close enabled" : "Enable auto-close when inactive")
+
                     Toggle("", isOn: Binding(
                         get: { app.isEnabled },
                         set: { _ in manager.toggleApp(app) }


### PR DESCRIPTION
## Summary
- Per-app auto-close toggle terminates protected apps after configurable inactivity timeout
- Prevents notifications from locked messaging apps (WhatsApp, iMessage, Telegram)
- New `AppInactivityService` tracks app focus and manages per-app close timers
- Global timeout slider in General Settings (1-60 min, default 15)
- Timer icon toggle per app in Protected Apps list (gold = enabled)

## Test plan
- [x] Add Chess to protected apps, enable auto-close (timer icon)
- [x] Set timeout to 2 min, switch away from Chess → Chess quits after 2 min
- [x] Reopen Chess → overlay + Touch ID/Watch auth appears
- [x] Keep Chess focused → does NOT auto-close
- [x] Slider value persists correctly across app restarts
- [x] Blacklisted apps (Terminal, Xcode) cannot be auto-closed