### PR TITLE
Terminate auto-close apps on sleep

### DIFF
--- a/MakLock/Core/Services/SleepWakeService.swift
+++ b/MakLock/Core/Services/SleepWakeService.swift
@@ -51,8 +51,7 @@ final class SleepWakeService {
     // MARK: - Handlers
 
     @objc private func handleSleep(_ notification: Notification) {
-        guard Defaults.shared.appSettings.lockOnSleep else { return }
-        NSLog("[MakLock] System going to sleep — triggering auto-lock")
+        NSLog("[MakLock] System going to sleep")
         onSleep?()
     }
 


### PR DESCRIPTION
## Summary
- Apps with auto-close enabled are terminated immediately when Mac sleeps
- Prevents notification snooping (someone opens laptop, knows password, sees WhatsApp/iMessage)
- Works independently of "Lock on sleep" setting
- Blacklisted apps (Terminal, Xcode) are never terminated

## Test plan
- [ ] Add Chess to protected apps with auto-close enabled
- [ ] Open Chess, put Mac to sleep
- [ ] Wake Mac → Chess should be closed
- [ ] Open Chess again → overlay + auth required
- [ ] Apps WITHOUT auto-close should only get overlay (if lockOnSleep enabled)