### PR TITLE
Require auth to open menu bar popover

### DIFF
--- a/MakLock.xcodeproj/project.pbxproj
+++ b/MakLock.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		A10000000000000000000D02 /* OnboardingWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000D12 /* OnboardingWindow.swift */; };
 		A10000000000000000000E01 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000E11 /* AboutView.swift */; };
 		A10000000000000000000F03 /* HotKey in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000F02 /* HotKey */; };
+		A10000000000000000001001 /* SettingsAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000001011 /* SettingsAuthService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -100,6 +101,7 @@
 		A10000000000000000000D11 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		A10000000000000000000D12 /* OnboardingWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWindow.swift; sourceTree = "<group>"; };
 		A10000000000000000000E11 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
+		A10000000000000000001011 /* SettingsAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAuthService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -181,6 +183,7 @@
 				A10000000000000000000B11 /* SleepWakeService.swift */,
 				A10000000000000000000C11 /* WatchProximityService.swift */,
 				4D8AAF1355AD0ACA8137F01D /* AppInactivityService.swift */,
+				A10000000000000000001011 /* SettingsAuthService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -419,6 +422,7 @@
 				A10000000000000000000D02 /* OnboardingWindow.swift in Sources */,
 				A10000000000000000000E01 /* AboutView.swift in Sources */,
 				3C36B23C6F719E84D10ECE91 /* AppInactivityService.swift in Sources */,
+				A10000000000000000001001 /* SettingsAuthService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MakLock/Core/Services/SettingsAuthService.swift
+++ b/MakLock/Core/Services/SettingsAuthService.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Manages authentication for accessing the menu bar popover.
+///
+/// Every click on the menu bar icon requires Touch ID (native system dialog
+/// with macOS password fallback) or Apple Watch on wrist. No grace period —
+/// each interaction is authenticated independently.
+final class SettingsAuthService {
+    static let shared = SettingsAuthService()
+
+    private init() {}
+
+    /// Whether Apple Watch can bypass the challenge (on wrist + in range).
+    var canWatchBypass: Bool {
+        let settings = Defaults.shared.appSettings
+        let watch = WatchProximityService.shared
+        return settings.useWatchUnlock
+            && watch.isWatchInRange
+            && (watch.isWatchUnlocked ?? true)
+    }
+
+    /// Whether no authentication method is available (safety valve).
+    /// If the user has no Touch ID and no backup password, we can't gate settings
+    /// or they'd be locked out permanently.
+    private var hasNoAuthMethod: Bool {
+        !AuthenticationService.shared.isTouchIDAvailable
+            && !KeychainManager.shared.hasPassword()
+    }
+
+    /// Authenticate before opening the menu bar popover.
+    ///
+    /// - Watch on wrist → bypass with toast
+    /// - No auth method → bypass silently (safety valve)
+    /// - Otherwise → native Touch ID dialog with macOS password fallback
+    func authenticate(completion: @escaping (Bool) -> Void) {
+        if hasNoAuthMethod {
+            completion(true)
+            return
+        }
+
+        if canWatchBypass {
+            completion(true)
+            // Show toast after popover has opened
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                WatchUnlockToast.shared.show()
+            }
+            return
+        }
+
+        // Don't double-trigger if Touch ID is already in progress (e.g. app lock overlay)
+        guard !AuthenticationService.shared.isAuthenticating else {
+            completion(false)
+            return
+        }
+
+        AuthenticationService.shared.authenticateWithSystemFallback(
+            reason: "Access MakLock Settings"
+        ) { result in
+            switch result {
+            case .success:
+                completion(true)
+            case .failure, .cancelled:
+                completion(false)
+            }
+        }
+    }
+}

--- a/MakLock/UI/LockOverlay/WatchUnlockToast.swift
+++ b/MakLock/UI/LockOverlay/WatchUnlockToast.swift
@@ -25,7 +25,7 @@ final class WatchUnlockToast {
         toast.isOpaque = false
         toast.backgroundColor = .clear
         toast.hasShadow = false
-        toast.level = .floating
+        toast.level = .popUpMenu
         toast.hidesOnDeactivate = false
         toast.collectionBehavior = [.canJoinAllSpaces, .transient]
         toast.isMovableByWindowBackground = false

--- a/MakLock/UI/MenuBar/MenuBarController.swift
+++ b/MakLock/UI/MenuBar/MenuBarController.swift
@@ -55,7 +55,12 @@ final class MenuBarController {
         if let popover, popover.isShown {
             hidePopover()
         } else {
-            popover?.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            // Require authentication before showing the popover
+            SettingsAuthService.shared.authenticate { [weak self] success in
+                guard success else { return }
+                NSApp.activate(ignoringOtherApps: true)
+                self?.popover?.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Every click on the menu bar icon now requires **Touch ID** (with macOS password fallback) or **Apple Watch on wrist** before the popover opens
- Apple Watch bypass shows a toast notification confirming unlock
- No grace period — each interaction is authenticated independently
- Safety valve: if no Touch ID + no backup password available, auth is skipped to prevent lockout

## Files changed
- `SettingsAuthService.swift` (NEW) — auth orchestration, Watch bypass, safety valve
- `AuthenticationService.swift` — added `authenticateWithSystemFallback()` using `.deviceOwnerAuthentication`
- `MenuBarController.swift` — auth gate in `togglePopover()`, `NSApp.activate()` for transient popover fix
- `WatchUnlockToast.swift` — toast level raised to `.popUpMenu` (visible above popover)

## Test plan
- [ ] Click menu bar icon with Watch on wrist → popover opens + toast visible
- [ ] Click menu bar icon without Watch → Touch ID dialog appears
- [ ] Cancel Touch ID → popover does NOT open
- [ ] After auth, click outside popover → popover closes
- [ ] App lock grace period still works for protected apps (unchanged)