### PR TITLE
Add Sparkle 2 auto-updates

### DIFF
--- a/MakLock.xcodeproj/project.pbxproj
+++ b/MakLock.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		A10000000000000000000E01 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000E11 /* AboutView.swift */; };
 		A10000000000000000000F03 /* HotKey in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000F02 /* HotKey */; };
 		A10000000000000000001001 /* SettingsAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000001011 /* SettingsAuthService.swift */; };
+		A10000000000000000001101 /* UpdateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000001111 /* UpdateService.swift */; };
+		A10000000000000000001203 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000001202 /* Sparkle */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -102,6 +104,7 @@
 		A10000000000000000000D12 /* OnboardingWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWindow.swift; sourceTree = "<group>"; };
 		A10000000000000000000E11 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		A10000000000000000001011 /* SettingsAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAuthService.swift; sourceTree = "<group>"; };
+		A10000000000000000001111 /* UpdateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -110,6 +113,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A10000000000000000000F03 /* HotKey in Frameworks */,
+				A10000000000000000001203 /* Sparkle in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -184,6 +188,7 @@
 				A10000000000000000000C11 /* WatchProximityService.swift */,
 				4D8AAF1355AD0ACA8137F01D /* AppInactivityService.swift */,
 				A10000000000000000001011 /* SettingsAuthService.swift */,
+				A10000000000000000001111 /* UpdateService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -323,6 +328,7 @@
 			name = MakLock;
 			packageProductDependencies = (
 				A10000000000000000000F02 /* HotKey */,
+				A10000000000000000001202 /* Sparkle */,
 			);
 			productName = MakLock;
 			productReference = A10000000000000000000010 /* MakLock.app */;
@@ -354,6 +360,7 @@
 			mainGroup = A10000000000000000000030;
 			packageReferences = (
 				A10000000000000000000F01 /* XCRemoteSwiftPackageReference "HotKey" */,
+				A10000000000000000001201 /* XCRemoteSwiftPackageReference "Sparkle" */,
 			);
 			productRefGroup = A10000000000000000000034 /* Products */;
 			projectDirPath = "";
@@ -423,6 +430,7 @@
 				A10000000000000000000E01 /* AboutView.swift in Sources */,
 				3C36B23C6F719E84D10ECE91 /* AppInactivityService.swift in Sources */,
 				A10000000000000000001001 /* SettingsAuthService.swift in Sources */,
+				A10000000000000000001101 /* UpdateService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -633,6 +641,14 @@
 				minimumVersion = 0.2.1;
 			};
 		};
+		A10000000000000000001201 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -640,6 +656,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A10000000000000000000F01 /* XCRemoteSwiftPackageReference "HotKey" */;
 			productName = HotKey;
+		};
+		A10000000000000000001202 /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A10000000000000000001201 /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/MakLock/App/AppDelegate.swift
+++ b/MakLock/App/AppDelegate.swift
@@ -8,6 +8,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         menuBarController.setup()
 
+        // Initialize Sparkle auto-updater
+        UpdateService.shared.start()
+
         // Request notification permission (for Watch unlock notifications)
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
 

--- a/MakLock/Core/Services/UpdateService.swift
+++ b/MakLock/Core/Services/UpdateService.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Sparkle
+import UserNotifications
+
+/// Manages automatic updates via Sparkle 2.
+///
+/// Uses `SPUStandardUpdaterController` for the standard update UI.
+/// Implements gentle update reminders for menu bar (LSUIElement) apps —
+/// background update checks post a macOS notification instead of
+/// showing a modal window that would be hidden behind other apps.
+final class UpdateService: NSObject, SPUStandardUserDriverDelegate {
+    static let shared = UpdateService()
+
+    /// Lazy so `self` is available as `userDriverDelegate` at creation time.
+    private(set) lazy var controller: SPUStandardUpdaterController = {
+        SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: self
+        )
+    }()
+
+    /// The underlying updater for programmatic access (e.g. "Check for Updates" button).
+    var updater: SPUUpdater { controller.updater }
+
+    private override init() {
+        super.init()
+    }
+
+    /// Trigger lazy initialization of the controller (call from AppDelegate).
+    func start() {
+        _ = controller
+    }
+
+    // MARK: - SPUStandardUserDriverDelegate (Gentle Reminders)
+
+    var supportsGentleScheduledUpdateReminders: Bool { true }
+
+    func standardUserDriverShouldHandleShowingScheduledUpdate(
+        _ update: SUAppcastItem,
+        andInImmediateFocus immediateFocus: Bool
+    ) -> Bool {
+        // If app is in immediate focus (user just launched), show standard Sparkle UI
+        if immediateFocus { return true }
+
+        // Background update found → post a macOS notification
+        postUpdateNotification(version: update.displayVersionString)
+        return false
+    }
+
+    private func postUpdateNotification(version: String) {
+        let content = UNMutableNotificationContent()
+        content.title = "MakLock Update Available"
+        content.body = "Version \(version) is ready to install."
+        content.sound = nil
+
+        let request = UNNotificationRequest(
+            identifier: "maklock-update",
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request)
+    }
+}

--- a/MakLock/Resources/Info.plist
+++ b/MakLock/Resources/Info.plist
@@ -6,5 +6,11 @@
 	<true/>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>MakLock uses Bluetooth to detect your Apple Watch for proximity unlock.</string>
+	<key>SUFeedURL</key>
+	<string>https://dutkiewiczmaciej.github.io/maklock/appcast.xml</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUScheduledCheckInterval</key>
+	<integer>86400</integer>
 </dict>
 </plist>

--- a/MakLock/UI/LockOverlay/WatchUnlockToast.swift
+++ b/MakLock/UI/LockOverlay/WatchUnlockToast.swift
@@ -55,10 +55,12 @@ final class WatchUnlockToast {
             toast.animator().alphaValue = 1
         }
 
-        // Auto-dismiss after 4 seconds
-        dismissTimer = Timer.scheduledTimer(withTimeInterval: 4.0, repeats: false) { [weak self] _ in
+        // Auto-dismiss after 4 seconds (use .common mode so it fires during modal dialogs)
+        let timer = Timer(timeInterval: 4.0, repeats: false) { [weak self] _ in
             self?.dismiss()
         }
+        RunLoop.main.add(timer, forMode: .common)
+        dismissTimer = timer
     }
 
     /// Find the screen containing the frontmost window of the given app.

--- a/MakLock/UI/Settings/GeneralSettingsView.swift
+++ b/MakLock/UI/Settings/GeneralSettingsView.swift
@@ -4,6 +4,8 @@ import ServiceManagement
 /// General settings tab: launch at login, idle auto-lock, sleep auto-lock.
 struct GeneralSettingsView: View {
     @State private var settings = Defaults.shared.appSettings
+    private let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+    private let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
 
     var body: some View {
         Form {
@@ -71,6 +73,25 @@ struct GeneralSettingsView: View {
                 Text("Apps with the timer icon enabled will quit after this period of inactivity.")
                     .font(MakLockTypography.caption)
                     .foregroundColor(MakLockColors.textSecondary)
+            }
+
+            Section {
+                Button("Check for Updates…") {
+                    UpdateService.shared.updater.checkForUpdates()
+                }
+
+                HStack(spacing: 8) {
+                    Text("MakLock \(version) (\(build))  ·  Made by MakMak")
+                        .foregroundColor(MakLockColors.textSecondary)
+                    Link(destination: URL(string: "https://github.com/dutkiewiczmaciej/MakLock")!) {
+                        HStack(spacing: 3) {
+                            Image(systemName: "arrow.up.right.square")
+                            Text("GitHub")
+                        }
+                        .foregroundColor(MakLockColors.gold)
+                    }
+                }
+                .font(MakLockTypography.caption)
             }
         }
         .formStyle(.grouped)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ AppLocker only locks apps on launch — if an app is already open, switching bac
 - [x] Multi-monitor support
 - [x] First launch onboarding
 - [x] Settings with tabbed UI
+- [x] Automatic updates via Sparkle 2
 - [ ] Trusted Wi-Fi auto-unlock *(coming in v1.1)*
 - [ ] Per-window overlay *(coming in v1.2)*
 
@@ -126,7 +127,7 @@ MakLock/
   Resources/  Assets, Info.plist, Entitlements
 ```
 
-**Key frameworks:** SwiftUI, AppKit, LocalAuthentication, CoreBluetooth, IOKit, ServiceManagement, HotKey (SPM)
+**Key frameworks:** SwiftUI, AppKit, LocalAuthentication, CoreBluetooth, IOKit, ServiceManagement, HotKey (SPM), Sparkle 2 (SPM)
 
 ## Safety
 

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <channel>
+        <title>MakLock Updates</title>
+        <link>https://dutkiewiczmaciej.github.io/maklock/</link>
+        <description>Most recent updates to MakLock</description>
+        <language>en</language>
+    </channel>
+</rss>


### PR DESCRIPTION
## Summary
- Integrate **Sparkle 2** via SPM for automatic update checking
- Add "Check for Updates…" button in Settings → General
- Add version/author/GitHub footer in General Settings
- Host appcast.xml on GitHub Pages, DMGs from GitHub Releases
- Gentle update reminders for menu bar app (macOS notification instead of modal)
- Fix Watch unlock toast not dismissing during modal dialogs (RunLoop `.common` mode)

## Before first release
- [ ] Run `generate_keys` to create EdDSA key pair
- [ ] Add `SUPublicEDKey` to Info.plist with the generated public key

## Files
- `UpdateService.swift` (NEW) — Sparkle wrapper with gentle reminders
- `docs/appcast.xml` (NEW) — empty placeholder for GitHub Pages
- `project.pbxproj` — Sparkle SPM dependency
- `Info.plist` — SUFeedURL + auto-check config
- `AppDelegate.swift` — initialize UpdateService on launch
- `GeneralSettingsView.swift` — Check for Updates button + version footer
- `WatchUnlockToast.swift` — timer fix for modal dialogs
- `README.md` — mention Sparkle 2 in features + frameworks